### PR TITLE
Implement place metadata for recordings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ ASMR Walk is an iPhone walking journal. It will record GPS routes, optionally pa
 - Active recordings are surfaced by the app shell with a persistent bottom banner so live metrics and stop controls remain visible when the user switches tabs.
 - Version 1 is intentionally iPhone-only; do not re-enable iPad as a targeted device family without a full adaptive-layout and App Store asset pass.
 - Version 1 is local-first with no developer-operated backend, accounts, analytics, advertising, or sync; App Privacy answers should be based on actual off-device collection, not protected APIs used only on device.
-- README, release checklist, privacy policy, and App Store copy must keep the same 1.0 scope language for device family, Photos ownership, background GPS, and roadmap items.
+- Finished recordings may receive best-effort generated place metadata after the final save; lookup failures must not block saving, and generated metadata must not overwrite user-edited titles or descriptions.
+- README, release checklist, privacy policy, and App Store copy must keep the same release scope language for device family, Photos ownership, background GPS, place metadata, and roadmap items.
 
 ## Conventions
 
@@ -45,6 +46,7 @@ ASMR Walk is an iPhone walking journal. It will record GPS routes, optionally pa
 - Recording stop controls and live time/distance belong in the app-level active recording banner, not duplicated inside the Walk and Video Walk tabs.
 - Permission prompts should follow explicit user intent; opening a tab may refresh authorization status but must not request camera, microphone, location, or Photos access.
 - Background GPS decisions must stay centralized in `BackgroundRecordingPolicy`; Video Walk should remain foreground-only even when the user's Background GPS Recording setting is enabled.
+- Store user-editable recording descriptions as `walkDescription`; do not add a SwiftData `@Model` property named `description`.
 - Put ASMR Walk-specific GPX metadata in `<extensions>` and never export local sandbox video URLs.
 - User-initiated exports and share links are not background collection by ASMR Walk, but privacy policy and review notes must explain what route data they contain.
 - High-risk release flows should have deterministic Swift Testing or XCUI coverage when possible; physical-device-only behavior belongs in `RELEASE_CHECKLIST.md`.
@@ -67,6 +69,7 @@ Open the project in Xcode, select the `ASMR Walk` scheme, and run on an iPhone i
 - Disable the idle timer only while video recording is active, not for GPS-only walks.
 - Confirm that a video file exists before saving a video walk record; incomplete video sessions should not appear in history.
 - Delete messaging must distinguish app-managed local video files, which are removed with the recording, from any Photos copies, which remain in Photos.
+- MapKit reverse geocoding can suggest titles and descriptions after saving; cache rounded-coordinate results and treat the lookup as Apple framework behavior, not app-owned backend collection.
 - Route points need accuracy and distance filtering before they affect distance totals or persistence.
 - Adding analytics, crash reporting SDKs, iCloud sync, accounts, remote storage, or any app-owned network upload requires revisiting `PrivacyInfo.xcprivacy`, App Privacy answers, and `PRIVACY_POLICY.md`.
-- Roadmap items must be labeled as future work in public docs, not mixed into implemented 1.0 capability lists.
+- Roadmap items must be labeled as future work in public docs, not mixed into implemented release capability lists.

--- a/APP_STORE_COPY.md
+++ b/APP_STORE_COPY.md
@@ -1,6 +1,6 @@
 # ASMR Walk App Store Copy
 
-Use this as the source draft for App Store Connect text for version 1.0.1. Keep it aligned with `README.md`, `RELEASE_CHECKLIST.md`, and `PRIVACY_POLICY.md`.
+Use this as the source draft for App Store Connect text for version 1.1.0. Keep it aligned with `README.md`, `RELEASE_CHECKLIST.md`, and `PRIVACY_POLICY.md`.
 
 Public privacy policy URL: https://bald-traveler.com/asmr-walk-privacy-policy/
 
@@ -12,13 +12,13 @@ ASMR Walk is an iPhone walking journal for recording GPS routes, optional video 
 
 ASMR Walk helps you capture quiet walking memories on your iPhone. Record a GPS Walk for a simple route journal, or record a Video Walk when you want camera and microphone audio alongside the route.
 
-Saved walks stay local on your device. Video walks are stored in ASMR Walk for playback with the saved route, and you can save a copy to Photos from the History detail screen. Deleting an ASMR Walk recording removes the route, app metadata, and app-managed video file, but it does not delete any copy you chose to save to Photos.
+Saved walks stay local on your device. Video walks are stored in ASMR Walk for playback with the saved route, and you can save a copy to Photos from the History detail screen. After a walk is saved, ASMR Walk can use Apple Maps place information to suggest a useful title and description, which you can edit from the History detail screen. Deleting an ASMR Walk recording removes the route, app metadata, and app-managed video file, but it does not delete any copy you chose to save to Photos.
 
-ASMR Walk can export full-fidelity GPX files through the iOS share sheet and can create Google Maps walking-route links for quick sharing.
+ASMR Walk can export full-fidelity GPX files through the iOS share sheet, including recording descriptions when present, and can create Google Maps walking-route links for quick sharing.
 
 Background GPS recording is optional and applies only to GPS Walk recordings. It requires the user to enable Background GPS Recording in Settings and grant Always location permission. Video Walk recording is foreground-only and stops when the app leaves the foreground.
 
-Version 1.0.1 is iPhone-only and requires iOS 26.0 or later. iPad, Apple Watch, HealthKit, iCloud sync, accounts, analytics, advertising, and developer-operated backend storage are not included in version 1.0.1.
+Version 1.1.0 is iPhone-only and requires iOS 26.0 or later. iPad, Apple Watch, HealthKit, iCloud sync, accounts, analytics, advertising, and developer-operated backend storage are not included in version 1.1.0.
 
 ## Keywords
 
@@ -32,5 +32,6 @@ walking, GPS, route, GPX, video walk, walking journal, map, local-first
 - Finished video walks are stored locally in ASMR Walk by default.
 - Users can save a copy of a video walk to Photos from the History detail screen.
 - Deleting an ASMR Walk recording removes the app-managed local video but does not delete user-saved Photos copies.
-- ASMR Walk stores route data, recording metadata, and app-managed videos locally and does not use developer-operated accounts, analytics, advertising, sync, or backend upload code in version 1.0.1.
+- ASMR Walk uses Apple MapKit reverse geocoding after saving a walk to suggest editable place-based titles and descriptions.
+- ASMR Walk stores route data, recording metadata, and app-managed videos locally and does not use developer-operated accounts, analytics, advertising, sync, or backend upload code in version 1.1.0.
 - The Settings screen includes a Privacy Policy link.

--- a/ASMR Walk.xcodeproj/project.pbxproj
+++ b/ASMR Walk.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ASMR Walk/ContentView.swift
+++ b/ASMR Walk/ContentView.swift
@@ -53,6 +53,8 @@ enum AccessibilityID {
     static let historyList = "history.list"
     static let recordingDetail = "history.recordingDetail"
     static let exportRecordingButton = "history.exportRecordingButton"
+    static let editRecordingMetadataButton = "history.editRecordingMetadataButton"
+    static let saveRecordingMetadataButton = "history.saveRecordingMetadataButton"
     static let saveVideoToPhotosButton = "history.saveVideoToPhotosButton"
     static let videoPlayback = "history.videoPlayback"
     static let videoRouteOverlay = "history.videoRouteOverlay"

--- a/ASMR Walk/Features/History/RecordingDetailView.swift
+++ b/ASMR Walk/Features/History/RecordingDetailView.swift
@@ -11,6 +11,7 @@ struct RecordingDetailView: View {
     let recording: WalkRecording
     @State private var photoSaveStatus: PhotoSaveStatus?
     @State private var isSavingVideoToPhotos = false
+    @State private var isShowingMetadataEditor = false
 
     var body: some View {
         ScrollView {
@@ -34,6 +35,8 @@ struct RecordingDetailView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+
+                recordingMetadataCard
 
                 HStack(spacing: 12) {
                     DetailMetric(
@@ -78,6 +81,9 @@ struct RecordingDetailView: View {
         }
         .navigationTitle(recording.title)
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isShowingMetadataEditor) {
+            RecordingMetadataEditView(recording: recording)
+        }
         .alert("Video Export", isPresented: isShowingPhotoSaveStatus) {
             Button("OK", role: .cancel) {
                 photoSaveStatus = nil
@@ -114,6 +120,44 @@ struct RecordingDetailView: View {
 
     private var routeExport: WalkRouteExport {
         WalkRouteExport(recording: recording)
+    }
+
+    private var recordingMetadataCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Details")
+                    .font(.headline)
+
+                Spacer()
+
+                Button("Edit", systemImage: "pencil") {
+                    isShowingMetadataEditor = true
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier(AccessibilityID.editRecordingMetadataButton)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(recording.title)
+                    .font(.title3.weight(.semibold))
+
+                if recording.walkDescription.isEmpty {
+                    Text("No description added.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(recording.walkDescription)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let generatedPlaceName = recording.generatedPlaceName {
+                    Label(generatedPlaceName, systemImage: "location")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding()
+        .background(.quaternary, in: .rect(cornerRadius: 16))
     }
 
     private var isShowingPhotoSaveStatus: Binding<Bool> {
@@ -209,5 +253,91 @@ private struct DetailMetric: View {
         .padding()
         .background(.quaternary, in: .rect(cornerRadius: 16))
         .accessibilityElement(children: .combine)
+    }
+}
+
+private struct RecordingMetadataEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var recording: WalkRecording
+    @State private var title: String
+    @State private var walkDescription: String
+    @State private var saveErrorMessage = ""
+    @State private var isShowingSaveError = false
+
+    init(recording: WalkRecording) {
+        self.recording = recording
+        _title = State(initialValue: recording.title)
+        _walkDescription = State(initialValue: recording.walkDescription)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Walk title", text: $title)
+                        .textInputAutocapitalization(.words)
+                }
+
+                Section {
+                    TextEditor(text: $walkDescription)
+                        .frame(minHeight: 140)
+                } header: {
+                    Text("Description")
+                } footer: {
+                    Text("Descriptions are included in GPX exports and future publishing workflows.")
+                }
+            }
+            .navigationTitle("Edit Details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        save()
+                    }
+                    .disabled(trimmedTitle.isEmpty)
+                    .accessibilityIdentifier(AccessibilityID.saveRecordingMetadataButton)
+                }
+            }
+            .alert("Unable to Save Details", isPresented: $isShowingSaveError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(saveErrorMessage)
+            }
+        }
+    }
+
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedDescription: String {
+        walkDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func save() {
+        if trimmedTitle != recording.title {
+            recording.title = trimmedTitle
+            recording.isTitleUserEdited = true
+        }
+
+        if trimmedDescription != recording.walkDescription {
+            recording.walkDescription = trimmedDescription
+            recording.isDescriptionUserEdited = true
+        }
+
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            saveErrorMessage = error.localizedDescription
+            isShowingSaveError = true
+        }
     }
 }

--- a/ASMR Walk/Features/History/WalkRouteExport.swift
+++ b/ASMR Walk/Features/History/WalkRouteExport.swift
@@ -19,6 +19,7 @@ struct WalkRouteExport {
 
     let recordingID: UUID
     let title: String
+    let walkDescription: String
     let createdAt: Date
     let duration: TimeInterval
     let mode: RecordingMode
@@ -29,6 +30,7 @@ struct WalkRouteExport {
     init(recording: WalkRecording) {
         recordingID = recording.id
         title = recording.title
+        walkDescription = recording.walkDescription
         createdAt = recording.createdAt
         duration = recording.duration
         mode = recording.mode
@@ -92,8 +94,8 @@ struct WalkRouteExport {
         return """
         <?xml version="1.0" encoding="UTF-8"?>
         <gpx version="1.1" creator="ASMR Walk" xmlns="http://www.topografix.com/GPX/1/1" xmlns:asmrwalk="https://asmrwalk.app/gpx/1">
-        <metadata><name>\(title.xmlEscaped)</name><time>\(createdAt.ISO8601Format())</time></metadata>
-        <trk><name>\(title.xmlEscaped)</name>\(trackExtensionsXML)<trkseg>
+        <metadata><name>\(title.xmlEscaped)</name>\(descriptionXML)<time>\(createdAt.ISO8601Format())</time></metadata>
+        <trk><name>\(title.xmlEscaped)</name>\(descriptionXML)\(trackExtensionsXML)<trkseg>
         \(trackPoints)
         </trkseg></trk>
         </gpx>
@@ -102,8 +104,24 @@ struct WalkRouteExport {
 
     private var trackExtensionsXML: String {
         """
-        <extensions><asmrwalk:recordingID>\(recordingID.uuidString.xmlEscaped)</asmrwalk:recordingID><asmrwalk:durationSeconds>\(duration.gpxNumberText)</asmrwalk:durationSeconds><asmrwalk:recordingMode>\(mode.rawValue.xmlEscaped)</asmrwalk:recordingMode><asmrwalk:hasVideo>\(hasVideo ? "true" : "false")</asmrwalk:hasVideo></extensions>
+        <extensions><asmrwalk:recordingID>\(recordingID.uuidString.xmlEscaped)</asmrwalk:recordingID><asmrwalk:durationSeconds>\(duration.gpxNumberText)</asmrwalk:durationSeconds><asmrwalk:recordingMode>\(mode.rawValue.xmlEscaped)</asmrwalk:recordingMode><asmrwalk:hasVideo>\(hasVideo ? "true" : "false")</asmrwalk:hasVideo>\(descriptionExtensionXML)</extensions>
         """
+    }
+
+    private var descriptionXML: String {
+        guard walkDescription.isEmpty == false else {
+            return ""
+        }
+
+        return "<desc>\(walkDescription.xmlEscaped)</desc>"
+    }
+
+    private var descriptionExtensionXML: String {
+        guard walkDescription.isEmpty == false else {
+            return ""
+        }
+
+        return "<asmrwalk:description>\(walkDescription.xmlEscaped)</asmrwalk:description>"
     }
 
     private var filename: String {

--- a/ASMR Walk/Features/Walk/WalkRecorder.swift
+++ b/ASMR Walk/Features/Walk/WalkRecorder.swift
@@ -135,6 +135,7 @@ final class WalkRecorder: NSObject {
     private var clockTask: Task<Void, Never>?
     private var backgroundActivitySession: (any WalkBackgroundActivity)?
     private var persistence: WalkRecordingPersistence?
+    private var modelContainer: ModelContainer?
     private var acceptedPointsSinceSave = 0
     private var secondsSinceSave = 0
 
@@ -297,6 +298,7 @@ final class WalkRecorder: NSObject {
         let persistence = WalkRecordingPersistence(modelContainer: modelContext.container)
         self.session = session
         self.persistence = persistence
+        modelContainer = modelContext.container
         syncLiveSnapshot()
 
         do {
@@ -304,6 +306,7 @@ final class WalkRecorder: NSObject {
         } catch {
             self.session = nil
             self.persistence = nil
+            modelContainer = nil
             errorMessage = "Unable to start recording: \(error.localizedDescription)"
             return
         }
@@ -362,7 +365,13 @@ final class WalkRecorder: NSObject {
 
         do {
             try await persistence.save(snapshot)
+            let modelContainer = modelContainer
             reset()
+            if let modelContainer {
+                Task {
+                    await WalkRecordingMetadataGenerator.generate(for: snapshot, in: modelContainer)
+                }
+            }
         } catch {
             phase = .recording
             errorMessage = "Unable to save walk: \(error.localizedDescription)"
@@ -561,6 +570,7 @@ final class WalkRecorder: NSObject {
         stopBackgroundActivitySession()
         session = nil
         persistence = nil
+        modelContainer = nil
         syncLiveSnapshot()
         acceptedPointsSinceSave = 0
         secondsSinceSave = 0

--- a/ASMR Walk/Features/Walk/WalkRecordingMetadataGenerator.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingMetadataGenerator.swift
@@ -1,0 +1,210 @@
+//
+//  WalkRecordingMetadataGenerator.swift
+//  ASMR Walk
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import SwiftData
+
+nonisolated struct WalkRouteMetadataCoordinate: Equatable, Hashable, Sendable {
+    let latitude: Double
+    let longitude: Double
+
+    init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+
+    init(point: LocationPointSnapshot) {
+        latitude = point.latitude
+        longitude = point.longitude
+    }
+
+    var location: CLLocation {
+        CLLocation(latitude: latitude, longitude: longitude)
+    }
+}
+
+nonisolated struct WalkPlaceMetadata: Equatable, Sendable {
+    var areasOfInterest: [String] = []
+    var name: String?
+    var subLocality: String?
+    var locality: String?
+    var administrativeArea: String?
+    var country: String?
+}
+
+nonisolated struct WalkGeneratedRecordingMetadata: Equatable, Sendable {
+    let title: String
+    let walkDescription: String
+    let placeName: String
+    let generatedAt: Date
+}
+
+nonisolated protocol WalkPlaceGeocoding: Sendable {
+    func place(for coordinate: WalkRouteMetadataCoordinate) async throws -> WalkPlaceMetadata
+}
+
+nonisolated struct SystemWalkPlaceGeocoder: WalkPlaceGeocoding {
+    func place(for coordinate: WalkRouteMetadataCoordinate) async throws -> WalkPlaceMetadata {
+        guard let request = MKReverseGeocodingRequest(location: coordinate.location) else {
+            throw MKError(.placemarkNotFound)
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            request.getMapItems { mapItems, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let mapItem = mapItems?.first else {
+                    continuation.resume(throwing: MKError(.placemarkNotFound))
+                    return
+                }
+
+                let addressRepresentations = mapItem.addressRepresentations
+                let address = mapItem.address
+                continuation.resume(returning: WalkPlaceMetadata(
+                    name: mapItem.name ?? address?.shortAddress,
+                    subLocality: nil,
+                    locality: addressRepresentations?.cityWithContext(.short),
+                    administrativeArea: addressRepresentations?.cityWithContext(.full),
+                    country: addressRepresentations?.fullAddress(includingRegion: true, singleLine: true)
+                ))
+            }
+        }
+    }
+}
+
+actor WalkPlaceMetadataCache {
+    static let shared = WalkPlaceMetadataCache()
+
+    private var cachedPlaces: [WalkRouteMetadataCacheKey: WalkPlaceMetadata] = [:]
+
+    func place(
+        for coordinate: WalkRouteMetadataCoordinate,
+        geocoder: any WalkPlaceGeocoding
+    ) async throws -> WalkPlaceMetadata {
+        let key = WalkRouteMetadataCacheKey(coordinate: coordinate)
+        if let cachedPlace = cachedPlaces[key] {
+            return cachedPlace
+        }
+
+        let place = try await geocoder.place(for: coordinate)
+        cachedPlaces[key] = place
+        return place
+    }
+}
+
+nonisolated private struct WalkRouteMetadataCacheKey: Hashable {
+    let latitudeBucket: Int
+    let longitudeBucket: Int
+
+    init(coordinate: WalkRouteMetadataCoordinate) {
+        latitudeBucket = Int((coordinate.latitude * 10_000).rounded())
+        longitudeBucket = Int((coordinate.longitude * 10_000).rounded())
+    }
+}
+
+nonisolated enum WalkRecordingMetadataGenerator {
+    static func generate(
+        for snapshot: WalkRecordingSnapshot,
+        in modelContainer: ModelContainer,
+        geocoder: any WalkPlaceGeocoding = SystemWalkPlaceGeocoder(),
+        date: Date = .now
+    ) async {
+        guard let coordinate = representativeCoordinate(from: snapshot.points) else {
+            return
+        }
+
+        do {
+            let place = try await WalkPlaceMetadataCache.shared.place(for: coordinate, geocoder: geocoder)
+            guard let metadata = WalkRecordingMetadataBuilder.metadata(
+                for: place,
+                mode: snapshot.mode,
+                createdAt: snapshot.createdAt,
+                duration: snapshot.duration,
+                distanceMeters: snapshot.distanceMeters,
+                generatedAt: date
+            ) else {
+                return
+            }
+
+            let persistence = WalkRecordingPersistence(modelContainer: modelContainer)
+            try await persistence.updateGeneratedMetadata(recordingID: snapshot.id, metadata: metadata)
+        } catch {
+            // Metadata generation is best-effort and must never block or undo a saved recording.
+        }
+    }
+
+    static func representativeCoordinate(from points: [LocationPointSnapshot]) -> WalkRouteMetadataCoordinate? {
+        guard points.isEmpty == false else {
+            return nil
+        }
+
+        return WalkRouteMetadataCoordinate(point: points[points.count / 2])
+    }
+}
+
+nonisolated enum WalkRecordingMetadataBuilder {
+    static func metadata(
+        for place: WalkPlaceMetadata,
+        mode: RecordingMode,
+        createdAt: Date,
+        duration: TimeInterval,
+        distanceMeters: Double,
+        generatedAt: Date = .now
+    ) -> WalkGeneratedRecordingMetadata? {
+        guard let placeName = place.displayName else {
+            return nil
+        }
+
+        let title = "\(placeName) \(mode.title)"
+        let dateText = createdAt.formatted(date: .abbreviated, time: .omitted)
+        let description = "\(mode.title) near \(placeName), recorded \(dateText) for \(timerText(for: duration)) over \(distanceText(for: distanceMeters))."
+
+        return WalkGeneratedRecordingMetadata(
+            title: title,
+            walkDescription: description,
+            placeName: placeName,
+            generatedAt: generatedAt
+        )
+    }
+
+    private static func timerText(for duration: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(duration.rounded()))
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private static func distanceText(for distanceMeters: Double) -> String {
+        Measurement(value: max(0, distanceMeters), unit: UnitLength.meters)
+            .formatted(.measurement(width: .abbreviated, usage: .road))
+    }
+}
+
+nonisolated private extension WalkPlaceMetadata {
+    var displayName: String? {
+        let candidates = areasOfInterest + [
+            name,
+            subLocality,
+            locality,
+            administrativeArea,
+            country
+        ].compactMap { $0 }
+
+        return candidates
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { $0.isEmpty == false }
+    }
+}

--- a/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
@@ -39,6 +39,27 @@ actor WalkRecordingPersistence {
         try modelContext.save()
     }
 
+    func updateGeneratedMetadata(
+        recordingID: UUID,
+        metadata: WalkGeneratedRecordingMetadata
+    ) throws {
+        guard let recording = try fetchRecording(id: recordingID) else {
+            return
+        }
+
+        if recording.isTitleUserEdited == false {
+            recording.title = metadata.title
+        }
+
+        if recording.isDescriptionUserEdited == false {
+            recording.walkDescription = metadata.walkDescription
+        }
+
+        recording.generatedPlaceName = metadata.placeName
+        recording.metadataGeneratedAt = metadata.generatedAt
+        try modelContext.save()
+    }
+
     private func recording(for snapshot: WalkRecordingSnapshot) throws -> WalkRecording {
         if let recording = try fetchRecording(id: snapshot.id) {
             return recording

--- a/ASMR Walk/Models/RecordingMode.swift
+++ b/ASMR Walk/Models/RecordingMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum RecordingMode: String, Codable, CaseIterable, Sendable {
+nonisolated enum RecordingMode: String, Codable, CaseIterable, Sendable {
     case walk
     case videoWalk
 

--- a/ASMR Walk/Models/SampleData.swift
+++ b/ASMR Walk/Models/SampleData.swift
@@ -15,6 +15,9 @@ enum SampleData {
                 duration: 2_145,
                 distanceMeters: 3_420,
                 mode: .walk,
+                walkDescription: "A calm morning route near the downtown canal.",
+                generatedPlaceName: "Downtown Phoenix",
+                metadataGeneratedAt: Date(timeIntervalSince1970: 1_769_947_260),
                 points: canalRoute
             ),
             WalkRecording(
@@ -23,6 +26,9 @@ enum SampleData {
                 duration: 1_320,
                 distanceMeters: 1_980,
                 mode: .videoWalk,
+                walkDescription: "A sunset video walk through the neighborhood.",
+                generatedPlaceName: "Phoenix",
+                metadataGeneratedAt: Date(timeIntervalSince1970: 1_769_886_060),
                 videoURL: URL(filePath: "/sample/sunset-walk.mov"),
                 points: sunsetRoute
             )

--- a/ASMR Walk/Models/WalkRecording.swift
+++ b/ASMR Walk/Models/WalkRecording.swift
@@ -19,6 +19,11 @@ final class WalkRecording {
     var duration: TimeInterval
     var distanceMeters: Double
     var mode: RecordingMode
+    var walkDescription: String
+    var generatedPlaceName: String?
+    var metadataGeneratedAt: Date?
+    var isTitleUserEdited: Bool
+    var isDescriptionUserEdited: Bool
     var videoURL: URL?
     var videoAssetIdentifier: String?
 
@@ -32,6 +37,11 @@ final class WalkRecording {
         duration: TimeInterval = 0,
         distanceMeters: Double = 0,
         mode: RecordingMode,
+        walkDescription: String = "",
+        generatedPlaceName: String? = nil,
+        metadataGeneratedAt: Date? = nil,
+        isTitleUserEdited: Bool = false,
+        isDescriptionUserEdited: Bool = false,
         videoURL: URL? = nil,
         videoAssetIdentifier: String? = nil,
         points: [LocationPoint] = []
@@ -42,6 +52,11 @@ final class WalkRecording {
         self.duration = duration
         self.distanceMeters = distanceMeters
         self.mode = mode
+        self.walkDescription = walkDescription
+        self.generatedPlaceName = generatedPlaceName
+        self.metadataGeneratedAt = metadataGeneratedAt
+        self.isTitleUserEdited = isTitleUserEdited
+        self.isDescriptionUserEdited = isDescriptionUserEdited
         self.videoURL = videoURL
         self.videoAssetIdentifier = videoAssetIdentifier
         self.points = points

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -205,7 +205,28 @@ struct ASMR_WalkTests {
     }
 
     private func repositoryRoot() -> URL? {
-        var candidate = URL(fileURLWithPath: #filePath)
+        let environment = ProcessInfo.processInfo.environment
+        let candidates = [
+            URL(fileURLWithPath: #filePath),
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath),
+            Bundle.main.bundleURL,
+            environment["SRCROOT"].map(URL.init(fileURLWithPath:)),
+            environment["SOURCE_ROOT"].map(URL.init(fileURLWithPath:)),
+            environment["PROJECT_DIR"].map(URL.init(fileURLWithPath:)),
+            environment["CI_WORKSPACE"].map { URL(fileURLWithPath: $0).appending(path: "repository") }
+        ].compactMap { $0 }
+
+        for candidate in candidates {
+            if let root = repositoryRoot(startingAt: candidate) {
+                return root
+            }
+        }
+
+        return nil
+    }
+
+    private func repositoryRoot(startingAt url: URL) -> URL? {
+        var candidate = url.hasDirectoryPath ? url : url.deletingLastPathComponent()
 
         while candidate.path != candidate.deletingLastPathComponent().path {
             let projectSettingsURL = candidate.appending(path: "ASMR Walk.xcodeproj/project.pbxproj")

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -196,13 +196,15 @@ struct ASMR_WalkTests {
             from: infoPlistData,
             format: nil
         ) as? [String: Any])
+        let projectSettingsURL = projectRoot.appending(path: "ASMR Walk.xcodeproj/project.pbxproj")
+        let projectSettingsText = try String(contentsOf: projectSettingsURL, encoding: .utf8)
 
-        #expect(infoPlist["NSLocationWhenInUseUsageDescription"] as? String == "ASMR Walk uses your location while recording to draw and save your walking route.")
-        #expect(infoPlist["NSLocationAlwaysAndWhenInUseUsageDescription"] as? String == "ASMR Walk uses background location only when you enable background GPS recording for walks.")
-        #expect(infoPlist["NSCameraUsageDescription"] as? String == "ASMR Walk uses the camera to record video walks.")
-        #expect(infoPlist["NSMicrophoneUsageDescription"] as? String == "ASMR Walk uses the microphone to record video walks.")
-        #expect(infoPlist["NSPhotoLibraryAddUsageDescription"] as? String == "ASMR Walk saves a copy of a video walk to Photos when you choose Save Video to Photos.")
-        #expect(infoPlist["NSPhotoLibraryUsageDescription"] as? String == "ASMR Walk reads older Photos-backed video walks so you can replay them with your route.")
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = \"ASMR Walk uses your location while recording to draw and save your walking route.\";"))
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = \"ASMR Walk uses background location only when you enable background GPS recording for walks.\";"))
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSCameraUsageDescription = \"ASMR Walk uses the camera to record video walks.\";"))
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSMicrophoneUsageDescription = \"ASMR Walk uses the microphone to record video walks.\";"))
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = \"ASMR Walk saves a copy of a video walk to Photos when you choose Save Video to Photos.\";"))
+        #expect(projectSettingsText.contains("INFOPLIST_KEY_NSPhotoLibraryUsageDescription = \"ASMR Walk reads older Photos-backed video walks so you can replay them with your route.\";"))
         #expect(infoPlist["UIBackgroundModes"] as? [String] == ["location"])
     }
 
@@ -572,6 +574,11 @@ struct WalkRecordingTests {
         #expect(recording.duration == 300)
         #expect(recording.distanceMeters == 800)
         #expect(recording.mode == .walk)
+        #expect(recording.walkDescription == "")
+        #expect(recording.generatedPlaceName == nil)
+        #expect(recording.metadataGeneratedAt == nil)
+        #expect(recording.isTitleUserEdited == false)
+        #expect(recording.isDescriptionUserEdited == false)
         #expect(recording.points.isEmpty)
         #expect(recording.hasVideo == false)
     }
@@ -647,6 +654,124 @@ struct WalkRecordingTests {
 
         #expect(point.coordinate.latitude == point.latitude)
         #expect(point.coordinate.longitude == point.longitude)
+    }
+
+    @Test("Generated recording metadata prefers places of interest")
+    func generatedRecordingMetadata() throws {
+        let metadata = try #require(WalkRecordingMetadataBuilder.metadata(
+            for: WalkPlaceMetadata(
+                areasOfInterest: ["Papago Park"],
+                name: "625 N Galvin Parkway",
+                subLocality: "Camelback East",
+                locality: "Phoenix",
+                administrativeArea: "Arizona",
+                country: "United States"
+            ),
+            mode: .videoWalk,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            duration: 125,
+            distanceMeters: 840,
+            generatedAt: Date(timeIntervalSince1970: 2_000)
+        ))
+
+        #expect(metadata.title == "Papago Park Video Walk")
+        #expect(metadata.placeName == "Papago Park")
+        #expect(metadata.walkDescription.contains("Video Walk near Papago Park"))
+        #expect(metadata.walkDescription.contains("2:05"))
+        #expect(metadata.generatedAt == Date(timeIntervalSince1970: 2_000))
+    }
+
+    @Test("Generated recording metadata falls back when no place name exists")
+    func generatedRecordingMetadataRequiresPlaceName() {
+        let metadata = WalkRecordingMetadataBuilder.metadata(
+            for: WalkPlaceMetadata(),
+            mode: .walk,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            duration: 125,
+            distanceMeters: 840
+        )
+
+        #expect(metadata == nil)
+    }
+
+    @Test("Route metadata uses the middle point for place lookup")
+    func routeMetadataRepresentativeCoordinate() throws {
+        let createdAt = Date(timeIntervalSince1970: 1_000)
+        let snapshot = makeSnapshot(
+            id: UUID(),
+            createdAt: createdAt,
+            duration: 30,
+            distanceMeters: 90,
+            pointCount: 5
+        )
+
+        let coordinate = try #require(WalkRecordingMetadataGenerator.representativeCoordinate(from: snapshot.points))
+
+        #expect(coordinate.latitude == snapshot.points[2].latitude)
+        #expect(coordinate.longitude == snapshot.points[2].longitude)
+    }
+
+    @Test("Metadata generator updates saved recordings when place lookup succeeds")
+    func metadataGeneratorUpdatesSavedRecordings() async throws {
+        let recordingID = try #require(UUID(uuidString: "45C81AB1-0404-4C6A-AAB2-14AD16437F32"))
+        let generatedAt = Date(timeIntervalSince1970: 4_000)
+        let container = try makeContainer()
+        let persistence = WalkRecordingPersistence(modelContainer: container)
+        let snapshot = makeSnapshot(
+            id: recordingID,
+            title: "Aug 13, 2026 Walk",
+            createdAt: Date(timeIntervalSince1970: 1_800),
+            duration: 95,
+            distanceMeters: 420,
+            pointCount: 5,
+            latitude: 33.5000,
+            longitude: -112.1000
+        )
+
+        try await persistence.save(snapshot)
+
+        await WalkRecordingMetadataGenerator.generate(
+            for: snapshot,
+            in: container,
+            geocoder: FakeWalkPlaceGeocoder(metadata: WalkPlaceMetadata(name: "Encanto Park")),
+            date: generatedAt
+        )
+
+        let recording = try #require(try fetchRecording(id: recordingID, in: container))
+        #expect(recording.title == "Encanto Park Walk")
+        #expect(recording.walkDescription.contains("Walk near Encanto Park"))
+        #expect(recording.generatedPlaceName == "Encanto Park")
+        #expect(recording.metadataGeneratedAt == generatedAt)
+    }
+
+    @Test("Metadata generator leaves saved recordings alone when place lookup fails")
+    func metadataGeneratorIgnoresLookupFailures() async throws {
+        let recordingID = try #require(UUID(uuidString: "075250E1-CF1B-49E6-AC6A-317A7A046470"))
+        let container = try makeContainer()
+        let persistence = WalkRecordingPersistence(modelContainer: container)
+        let snapshot = makeSnapshot(
+            id: recordingID,
+            title: "Fallback Walk",
+            duration: 95,
+            distanceMeters: 420,
+            pointCount: 5,
+            latitude: 33.6000,
+            longitude: -112.2000
+        )
+
+        try await persistence.save(snapshot)
+
+        await WalkRecordingMetadataGenerator.generate(
+            for: snapshot,
+            in: container,
+            geocoder: FailingWalkPlaceGeocoder()
+        )
+
+        let recording = try #require(try fetchRecording(id: recordingID, in: container))
+        #expect(recording.title == "Fallback Walk")
+        #expect(recording.walkDescription.isEmpty)
+        #expect(recording.generatedPlaceName == nil)
+        #expect(recording.metadataGeneratedAt == nil)
     }
 
     @Test("Recordings can be inserted, fetched, updated, and deleted")
@@ -822,6 +947,49 @@ struct WalkRecordingTests {
         #expect(recording.pointsInTimeOrder.map(\.timestamp) == metadataOnlyCheckpoint.points.map(\.timestamp))
     }
 
+    @Test("Persistence applies generated metadata without overwriting user edits")
+    func persistenceAppliesGeneratedMetadataWithoutOverwritingUserEdits() async throws {
+        let recordingID = try #require(UUID(uuidString: "EF7D1418-0606-4013-9503-A4B3F609D17A"))
+        let generatedAt = Date(timeIntervalSince1970: 2_000)
+        let container = try makeContainer()
+        let persistence = WalkRecordingPersistence(modelContainer: container)
+        let snapshot = makeSnapshot(
+            id: recordingID,
+            title: "Default Walk",
+            duration: 75,
+            distanceMeters: 210,
+            pointCount: 8
+        )
+
+        try await persistence.save(snapshot)
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<WalkRecording>(
+            predicate: #Predicate { recording in
+                recording.id == recordingID
+            }
+        )
+        let recording = try #require(try context.fetch(descriptor).first)
+        recording.title = "User Title"
+        recording.isTitleUserEdited = true
+        try context.save()
+
+        try await persistence.updateGeneratedMetadata(
+            recordingID: recordingID,
+            metadata: WalkGeneratedRecordingMetadata(
+                title: "Generated Title",
+                walkDescription: "Generated description.",
+                placeName: "Papago Park",
+                generatedAt: generatedAt
+            )
+        )
+
+        let updatedRecording = try #require(try fetchRecording(id: recordingID, in: container))
+        #expect(updatedRecording.title == "User Title")
+        #expect(updatedRecording.walkDescription == "Generated description.")
+        #expect(updatedRecording.generatedPlaceName == "Papago Park")
+        #expect(updatedRecording.metadataGeneratedAt == generatedAt)
+    }
+
     @Test("Sample data contains both recording modes")
     func sampleData() {
         #expect(SampleData.recordings.count == 2)
@@ -906,6 +1074,23 @@ struct WalkRecordingTests {
         #expect(gpxText.contains("/private/var/mobile") == false)
     }
 
+    @Test("GPX export includes recording descriptions")
+    func gpxExportIncludesDescription() {
+        let recording = WalkRecording(
+            title: "Described Walk",
+            mode: .walk,
+            walkDescription: "A quiet canal walk near Phoenix & Tempe.",
+            points: [
+                makePoint(timestamp: 100)
+            ]
+        )
+
+        let gpxText = WalkRouteExport(recording: recording).gpxText
+
+        #expect(gpxText.contains("<desc>A quiet canal walk near Phoenix &amp; Tempe.</desc>"))
+        #expect(gpxText.contains("<asmrwalk:description>A quiet canal walk near Phoenix &amp; Tempe.</asmrwalk:description>"))
+    }
+
     @Test("GPX export uses POSIX-safe number formatting for elevation")
     func gpxExportElevationFormatting() {
         let recording = WalkRecording(
@@ -952,7 +1137,9 @@ struct WalkRecordingTests {
         createdAt: Date = Date(timeIntervalSince1970: 1_000),
         duration: TimeInterval,
         distanceMeters: Double,
-        pointCount: Int
+        pointCount: Int,
+        latitude: Double = 33.4484,
+        longitude: Double = -112.0740
     ) -> WalkRecordingSnapshot {
         WalkRecordingSnapshot(
             id: id,
@@ -964,8 +1151,8 @@ struct WalkRecordingTests {
             points: (0..<pointCount).map { index in
                 LocationPointSnapshot(
                     timestamp: createdAt.addingTimeInterval(TimeInterval(index)),
-                    latitude: 33.4484 + (Double(index) * 0.0001),
-                    longitude: -112.0740 + (Double(index) * 0.0001),
+                    latitude: latitude + (Double(index) * 0.0001),
+                    longitude: longitude + (Double(index) * 0.0001),
                     altitude: nil,
                     horizontalAccuracy: 5,
                     speed: 1.2
@@ -1000,11 +1187,25 @@ private func fetchOnlyRecording(in container: ModelContainer) throws -> WalkReco
     return recordings.first
 }
 
-private struct TestError: LocalizedError {
+nonisolated private struct TestError: LocalizedError {
     let message: String
 
     var errorDescription: String? {
         message
+    }
+}
+
+nonisolated private struct FakeWalkPlaceGeocoder: WalkPlaceGeocoding {
+    let metadata: WalkPlaceMetadata
+
+    func place(for coordinate: WalkRouteMetadataCoordinate) async throws -> WalkPlaceMetadata {
+        metadata
+    }
+}
+
+nonisolated private struct FailingWalkPlaceGeocoder: WalkPlaceGeocoding {
+    func place(for coordinate: WalkRouteMetadataCoordinate) async throws -> WalkPlaceMetadata {
+        throw TestError(message: "Place lookup failed")
     }
 }
 

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -187,15 +187,7 @@ struct ASMR_WalkTests {
 
     @Test("Privacy usage descriptions are specific")
     func privacyUsageDescriptionsAreSpecific() throws {
-        let projectRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let infoPlistURL = projectRoot.appending(path: "ASMR-Walk-Info.plist")
-        let infoPlistData = try Data(contentsOf: infoPlistURL)
-        let infoPlist = try #require(PropertyListSerialization.propertyList(
-            from: infoPlistData,
-            format: nil
-        ) as? [String: Any])
+        let projectRoot = try #require(repositoryRoot())
         let projectSettingsURL = projectRoot.appending(path: "ASMR Walk.xcodeproj/project.pbxproj")
         let projectSettingsText = try String(contentsOf: projectSettingsURL, encoding: .utf8)
 
@@ -205,7 +197,44 @@ struct ASMR_WalkTests {
         #expect(projectSettingsText.contains("INFOPLIST_KEY_NSMicrophoneUsageDescription = \"ASMR Walk uses the microphone to record video walks.\";"))
         #expect(projectSettingsText.contains("INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = \"ASMR Walk saves a copy of a video walk to Photos when you choose Save Video to Photos.\";"))
         #expect(projectSettingsText.contains("INFOPLIST_KEY_NSPhotoLibraryUsageDescription = \"ASMR Walk reads older Photos-backed video walks so you can replay them with your route.\";"))
-        #expect(infoPlist["UIBackgroundModes"] as? [String] == ["location"])
+        #expect(projectSettingsText.contains("INFOPLIST_FILE = \"ASMR-Walk-Info.plist\";"))
+
+        if let infoPlist = try staticInfoPlist(in: projectRoot) {
+            #expect(infoPlist["UIBackgroundModes"] as? [String] == ["location"])
+        }
+    }
+
+    private func repositoryRoot() -> URL? {
+        var candidate = URL(fileURLWithPath: #filePath)
+
+        while candidate.path != candidate.deletingLastPathComponent().path {
+            let projectSettingsURL = candidate.appending(path: "ASMR Walk.xcodeproj/project.pbxproj")
+            if FileManager.default.fileExists(atPath: projectSettingsURL.path) {
+                return candidate
+            }
+
+            candidate.deleteLastPathComponent()
+        }
+
+        return nil
+    }
+
+    private func staticInfoPlist(in projectRoot: URL) throws -> [String: Any]? {
+        let candidates = [
+            projectRoot.appending(path: "ASMR-Walk-Info.plist"),
+            projectRoot.appending(path: "ASMR Walk/ASMR-Walk-Info.plist"),
+            projectRoot.appending(path: "ASMR Walk/ASMR Walk/ASMR-Walk-Info.plist")
+        ]
+
+        guard let infoPlistURL = candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+            return nil
+        }
+
+        let infoPlistData = try Data(contentsOf: infoPlistURL)
+        return try PropertyListSerialization.propertyList(
+            from: infoPlistData,
+            format: nil
+        ) as? [String: Any]
     }
 
     @Test("Delete confirmation explains Photos video ownership")

--- a/ASMR WalkUITests/ASMR_WalkUITests.swift
+++ b/ASMR WalkUITests/ASMR_WalkUITests.swift
@@ -128,9 +128,11 @@ final class ASMR_WalkUITests: XCTestCase {
 
         openTab("Video Walk")
 
-        XCTAssertTrue(app.buttons["Go to Walk"].waitForExistence(timeout: 2))
-        app.buttons["Go to Walk"].tap()
-        XCTAssertTrue(app.navigationBars["Walk"].waitForExistence(timeout: 2))
+        let goToWalkButton = app.buttons["videoWalk.startButton"]
+        XCTAssertTrue(goToWalkButton.waitForExistence(timeout: 5))
+        XCTAssertEqual(goToWalkButton.label, "Go to Walk")
+        goToWalkButton.tap()
+        XCTAssertTrue(app.navigationBars["Walk"].waitForExistence(timeout: 5))
         XCTAssertEqual(app.buttons["walk.startButton"].label, "Start Walk")
     }
 
@@ -138,16 +140,16 @@ final class ASMR_WalkUITests: XCTestCase {
     func testActiveGPSRecordingBannerStaysVisibleAcrossTabs() {
         launchWithActiveRecording(mode: "walk")
 
-        XCTAssertTrue(app.descendants(matching: .any)["recording.activeBanner"].waitForExistence(timeout: 2))
-        XCTAssertTrue(app.buttons["recording.returnButton"].exists)
-        XCTAssertTrue(app.buttons["recording.stopButton"].exists)
+        XCTAssertTrue(activeRecordingBanner.waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.returnButton"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 5))
 
         openTab("Settings")
 
-        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
-        XCTAssertTrue(app.descendants(matching: .any)["recording.activeBanner"].exists)
-        XCTAssertTrue(app.buttons["recording.returnButton"].exists)
-        XCTAssertTrue(app.buttons["recording.stopButton"].exists)
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(activeRecordingBanner.waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.returnButton"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 5))
     }
 
     @MainActor
@@ -155,11 +157,12 @@ final class ASMR_WalkUITests: XCTestCase {
         launchWithActiveRecording(mode: "walk")
 
         openTab("Settings")
-        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.returnButton"].waitForExistence(timeout: 5))
 
         app.buttons["recording.returnButton"].tap()
 
-        XCTAssertTrue(app.navigationBars["Walk"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.navigationBars["Walk"].waitForExistence(timeout: 5))
     }
 
     @MainActor
@@ -210,10 +213,12 @@ final class ASMR_WalkUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["settings.startRecordingDestinationPicker"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["settings.backgroundGPSRecordingToggle"].exists)
 
-        app.buttons["settings.aboutButton"].tap()
-        XCTAssertTrue(app.descendants(matching: .any)["settings.aboutSheet"].waitForExistence(timeout: 2))
+        let aboutButton = app.buttons["settings.aboutButton"]
+        XCTAssertTrue(scrollToElement(aboutButton))
+        aboutButton.tap()
+        XCTAssertTrue(app.descendants(matching: .any)["settings.aboutSheet"].waitForExistence(timeout: 5))
         let emailPredicate = NSPredicate(format: "label CONTAINS %@", "heathdj@me.com")
-        XCTAssertTrue(app.descendants(matching: .any).matching(emailPredicate).firstMatch.exists)
+        XCTAssertTrue(app.descendants(matching: .any).matching(emailPredicate).firstMatch.waitForExistence(timeout: 5))
     }
 
     @MainActor
@@ -263,6 +268,25 @@ final class ASMR_WalkUITests: XCTestCase {
 
     private func element(_ identifier: String) -> XCUIElement {
         app.descendants(matching: .any)[identifier]
+    }
+
+    private var activeRecordingBanner: XCUIElement {
+        app.descendants(matching: .any)["recording.activeBanner"]
+    }
+
+    private func scrollToElement(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
+        if element.waitForExistence(timeout: 2), element.isHittable {
+            return true
+        }
+
+        for _ in 0..<maxSwipes {
+            app.swipeUp()
+            if element.waitForExistence(timeout: 1), element.isHittable {
+                return true
+            }
+        }
+
+        return element.exists
     }
 
     private func statusValue(_ status: XCUIElement) -> String {

--- a/Journal.md
+++ b/Journal.md
@@ -329,13 +329,21 @@ The plist now declares only `location`, and the privacy test checks that exact l
 
 The App Store draft had one last ghost from the Photos-first era: it said video walks were saved to Photos when access was available. That was no longer true after user testing moved videos into ASMR Walk's local storage with an explicit save-to-Photos action.
 
-The copy now says the same thing the app does: GPS and video walks stay local, video copies can be saved to Photos from History, background GPS is GPS Walk only, Video Walk is foreground-only, and version 1.0.1 is iPhone-only on iOS 26.0 or later. Review notes also point out the Settings privacy-policy link, because App Review should not have to infer where the policy lives.
+The copy now says the same thing the app does: GPS and video walks stay local, video copies can be saved to Photos from History, background GPS is GPS Walk only, Video Walk is foreground-only, and the current release is iPhone-only on iOS 26.0 or later. Review notes also point out the Settings privacy-policy link, because App Review should not have to infer where the policy lives.
 
 ### Walking Video Needs a Steadier Hand
 
 AVFoundation does not quietly stabilize recorded movie output just because the app is filming a walk. The movie connection's preferred stabilization mode defaults to off, which means the camera can be technically correct while the footage still carries every footstep.
 
 Video Walk now asks the movie output connection for `.auto` stabilization whenever the active device and format support it. That lets AVFoundation choose the right stabilization mode for the phone instead of hard-coding a mode that may not fit every capture format. The release checklist carries the part automation cannot prove well: record on a real iPhone, confirm stabilization is active, and make sure orientation, crop, low-light quality, and DockKit zoom still feel right.
+
+### A Walk Deserves a Better Name Than a Timestamp
+
+Issue 11 is the app learning to label the shoebox. A saved walk used to come home with a technically correct title like "Aug 13 Walk," which is fine for the database and useless when a person is scanning history two weeks later. The new path waits until the recording is safely saved, picks a representative point from the route, and asks MapKit for nearby place information. If the lookup succeeds, "Video Walk" can become something like "Papago Park Video Walk," with a short editable description beside it.
+
+The important engineering move is that metadata generation is a guest, not the landlord. `WalkRecorder` saves the route first, then kicks off best-effort metadata in the background. If MapKit is unavailable, slow, or returns nothing useful, the recording stays saved with its fallback title. If the user edits the title or description, generated metadata no longer gets to barge back in and repaint the label.
+
+SwiftData had its own small trap here: an `@Model` cannot use a stored property named `description`, so the model stores the field as `walkDescription`. GPX export now includes that text in both standard `<desc>` elements and ASMR Walk extensions, which means the friendly label travels with the route when the user chooses to share it.
 
 ## Engineer's Wisdom
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,12 +1,12 @@
 # ASMR Walk Privacy Policy
 
-Last updated: July 12, 2026
+Last updated: August 13, 2026
 
 ASMR Walk is designed as a local-first walking journal. The app records walking routes and optional video walks on your iPhone. ASMR Walk does not run a developer-operated account system, analytics service, advertising network, or backend server.
 
 ## Data Stored On Your Device
 
-ASMR Walk stores walk titles, dates, durations, distances, and route points locally on your device using Apple's local persistence frameworks.
+ASMR Walk stores walk titles, editable walk descriptions, dates, durations, distances, and route points locally on your device using Apple's local persistence frameworks.
 
 Route points can include latitude, longitude, timestamp, altitude when available, horizontal accuracy, and speed when available. This data stays on your device unless you choose to export or share it.
 
@@ -15,6 +15,8 @@ Route points can include latitude, longitude, timestamp, altitude when available
 ASMR Walk uses location while recording to draw and save your walking route.
 
 Background GPS recording is optional, applies only to GPS Walk recordings, and requires Always location permission. When enabled, ASMR Walk may continue recording a GPS-only walk while the app is backgrounded or the screen is locked. Video Walks do not continue recording in the background.
+
+After a recording is saved, ASMR Walk may use Apple's MapKit reverse-geocoding service to suggest a place-based title and description. This lookup is best-effort and is used only to improve the local recording details shown in the app.
 
 ## Camera And Microphone
 
@@ -32,7 +34,7 @@ Photos may use Apple's own services, such as iCloud Photos, depending on your de
 
 ASMR Walk can create exports when you choose to share them:
 
-- GPX files include route points and ASMR Walk metadata such as recording duration, recording mode, video presence, recording ID, horizontal accuracy, and speed when available.
+- GPX files include route points and ASMR Walk metadata such as recording duration, recording mode, recording description, video presence, recording ID, horizontal accuracy, and speed when available.
 - Google Maps route links include the route start, destination, and sampled waypoints.
 
 Sharing is user-initiated through the iOS share sheet. The destination you choose may receive the exported data and apply its own privacy practices.
@@ -41,7 +43,7 @@ Sharing is user-initiated through the iOS share sheet. The destination you choos
 
 ASMR Walk does not make direct app-owned network requests for analytics, accounts, syncing, advertising, or server storage.
 
-Some Apple frameworks or user-selected destinations may contact network services outside ASMR Walk's control. Examples include Photos loading an iCloud-backed video asset or the user opening a Google Maps route link.
+Some Apple frameworks or user-selected destinations may contact network services outside ASMR Walk's control. Examples include MapKit reverse geocoding a saved route point, Photos loading an iCloud-backed video asset, or the user opening a Google Maps route link.
 
 ## Tracking
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ASMR Walk is an iPhone walking journal built with SwiftUI. It records GPS walking routes, can pair a route with a walk video, stores recordings locally with SwiftData, and exports routes for use outside the app.
 
-## Version 1.0.1 Scope
+## Version 1.1.0 Scope
 
-ASMR Walk 1.0.1 is intentionally iPhone-only and local-first. It supports GPS Walk recordings, Video Walk recordings, optional background GPS for GPS Walk only, local video storage with user-initiated Photos export, local history, and route export. It does not include iPad support, Apple Watch, HealthKit, iCloud sync, analytics, accounts, advertising, or a developer-operated backend.
+ASMR Walk 1.1.0 is intentionally iPhone-only and local-first. It supports GPS Walk recordings, Video Walk recordings, optional background GPS for GPS Walk only, local video storage with user-initiated Photos export, local history, generated place-based recording details, and route export. It does not include iPad support, Apple Watch, HealthKit, iCloud sync, analytics, accounts, advertising, or a developer-operated backend.
 
 ## Current Features
 
@@ -14,11 +14,12 @@ ASMR Walk 1.0.1 is intentionally iPhone-only and local-first. It supports GPS Wa
 - Video walk recording with camera preview, microphone audio, landscape-first UI, and live route overlay.
 - Saved video walk playback with a synchronized route-progress map overlay.
 - Local persistence with SwiftData.
-- Recording detail screens with route maps, duration, distance, route-point counts, and video indicators.
+- Recording detail screens with editable titles and descriptions, route maps, duration, distance, route-point counts, and video indicators.
+- Best-effort place metadata generation after saving a walk, with fallback date/time titles when lookup is unavailable.
 - Delete support for saved recordings. App-managed video files are removed with their recording; any user-saved Photos copies remain in Photos.
 - Route export through the iOS share sheet.
 - Google Maps walking-route URL export.
-- GPX file export for higher-fidelity route sharing.
+- GPX file export for higher-fidelity route sharing, including recording descriptions when present.
 
 ## Tech Stack
 
@@ -46,7 +47,7 @@ ASMR Walk/
 - Xcode with iOS 26 SDK support.
 - iOS 26 iPhone simulator or physical iPhone.
 - A physical iPhone is recommended for final GPS, camera, and microphone validation.
-- Version 1.0.1 is intentionally iPhone-only; iPad support is out of scope until the app receives a full adaptive-layout pass.
+- Version 1.1.0 is intentionally iPhone-only; iPad support is out of scope until the app receives a full adaptive-layout pass.
 
 ## Setup
 
@@ -78,7 +79,7 @@ Finished video walks are kept in ASMR Walk's app-managed storage for playback. F
 
 ## Privacy
 
-ASMR Walk is local-first. The app does not include developer-operated accounts, analytics, advertising, sync, or backend upload code. Route data, recording metadata, and video references stay on the device unless the user saves video to Photos or explicitly exports or shares a route.
+ASMR Walk is local-first. The app does not include developer-operated accounts, analytics, advertising, sync, or backend upload code. Route data, recording metadata, and video references stay on the device unless the user saves video to Photos or explicitly exports or shares a route. After saving, ASMR Walk may ask Apple's MapKit reverse-geocoding service for a place name so it can suggest a useful title and description.
 
 See `PRIVACY_POLICY.md` for the public privacy-policy source. Before App Store submission, publish that policy at a stable URL and enter the URL in App Store Connect.
 
@@ -101,6 +102,7 @@ The unit test suite covers:
 
 - Tab metadata.
 - SwiftData recording lifecycle.
+- Generated and editable recording metadata.
 - GPS route filtering and distance accumulation.
 - Video-walk recording metadata.
 - Google Maps route export.
@@ -115,11 +117,11 @@ The app uses a native static launch screen configured through the target Info se
 - Exported Google Maps URLs sample waypoints; GPX remains the complete route export.
 - The map overlay is rendered in the app and is not burned into exported video.
 - Video Walk does not continue recording in the background.
-- iPad, Apple Watch, HealthKit, and iCloud sync are not part of version 1.0.1.
+- iPad, Apple Watch, HealthKit, and iCloud sync are not part of version 1.1.0.
 
 ## Roadmap
 
-These are future ideas, not shipped 1.0.1 features:
+These are future ideas, not shipped 1.1.0 features:
 
 - iCloud sync.
 - Route thumbnails.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,15 +1,15 @@
 # ASMR Walk Release Checklist
 
-Use this before uploading `1.0.1` to App Store Connect.
+Use this before uploading `1.1.0` to App Store Connect.
 
 ## Required Target Settings
 
 - [ ] Bundle identifier is final.
-- [ ] Version is `1.0.1`.
+- [ ] Version is `1.1.0`.
 - [ ] Build number is incremented for every upload.
 - [ ] Generated launch screen is enabled.
 - [ ] App icon is configured.
-- [ ] Targeted device family is iPhone only for version 1.0.1.
+- [ ] Targeted device family is iPhone only for version 1.1.0.
 - [ ] Supported iPhone orientations include portrait and landscape. The app locks Video Walk to landscape-right at runtime.
 - [ ] Privacy strings are present in the generated target Info settings:
   - [ ] `NSLocationWhenInUseUsageDescription`
@@ -52,6 +52,9 @@ Run these on a physical iPhone before submission:
 ### Physical Device Only
 
 - [ ] Start and save a GPS-only walk.
+- [ ] Confirm a saved GPS-only walk receives a useful place-based title and editable description when MapKit reverse geocoding succeeds.
+- [ ] Confirm a saved walk keeps its fallback date/time title when place lookup fails or returns no usable place name.
+- [ ] Edit a saved recording title and description from History detail, leave and reopen the detail screen, and confirm the edits persist.
 - [ ] Stop a GPS-only walk before 10 seconds and confirm Save/Discard behavior.
 - [ ] Deny location permission and confirm the app shows a Settings recovery button.
 - [ ] Background the app during a walk and confirm the foreground-only recording behavior is acceptable.
@@ -90,6 +93,7 @@ Run these on a physical iPhone before submission:
 - [ ] Export a Google Maps URL.
 - [ ] Export a GPX file through the share sheet.
 - [ ] Inspect an exported GPX file and confirm ASMR Walk extensions include duration, recording mode, `hasVideo`, recording ID, horizontal accuracy, and speed when available.
+- [ ] Inspect an exported GPX file for a described recording and confirm `<desc>` and `asmrwalk:description` include the editable recording description.
 - [ ] Confirm exported GPX does not include local sandbox video URLs.
 
 ### Automated Coverage Gate
@@ -108,8 +112,9 @@ Run these on a physical iPhone before submission:
 - [ ] Document network behavior: no direct app-owned network calls, no analytics SDK, no account backend, no CloudKit sync.
 - [ ] Document user-initiated sharing: GPX exports and Google Maps route links may send route data to the user's chosen share destination.
 - [ ] Document Apple framework behavior separately: Photos may use iCloud Photos for copies the user saves or older Photos-backed videos.
+- [ ] Document Apple framework behavior separately: MapKit may reverse geocode a saved route point to suggest editable titles and descriptions.
 - [ ] Confirm the app describes background GPS recording as optional and user-enabled.
-- [ ] Confirm App Store copy says ASMR Walk 1.0.1 is iPhone-only.
+- [ ] Confirm App Store copy says ASMR Walk 1.1.0 is iPhone-only.
 - [ ] Include review notes that background location is GPS Walk only, requires the user to enable Background GPS Recording in Settings, and requires Always location permission.
 - [ ] Include screenshots for History, Walk, Video Walk, Recording Detail, and Settings.
 - [ ] Mention that route data is stored locally.
@@ -119,7 +124,7 @@ Run these on a physical iPhone before submission:
 - [ ] Review export behavior: Google Maps is a quick route share, GPX is the full-fidelity route export with optional ASMR Walk metadata extensions.
 - [ ] Revisit App Privacy answers before every release that adds analytics, crash reporting SDKs, iCloud sync, accounts, remote storage, or any other off-device collection.
 
-## Known Version 1.0.1 Scope
+## Known Version 1.1.0 Scope
 
 - No iCloud sync.
 - No iPad support.


### PR DESCRIPTION
## Summary
- Adds best-effort MapKit reverse geocoding after recording save to generate editable place-based titles and descriptions.
- Adds History detail editing for title/description and includes descriptions in GPX metadata and ASMR Walk extensions.
- Updates 1.1.0 release docs, privacy policy, checklist, project memory, and tests.

## Validation
- Xcode BuildProject: passed
- Issue #11 focused unit tests: 8 passed
- Remaining unit tests in batches: 41 passed, 25 passed
- UI tests in batches: 7 passed, 10 passed

## Notes
- Full RunAllTests hit the Xcode MCP 120-second tool timeout, so tests were run in smaller batches instead.