### PR TITLE
Generate route thumbnails for saved walks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ ASMR Walk is an iPhone walking journal. It will record GPS routes, optionally pa
 - `DockKitAccessoryService` owns DockKit accessory state and event streams for Video Walk; camera shutter toggles recording, camera zoom adjusts `VideoCaptureService`, and other accessory events intentionally no-op for now.
 - Video Walk locks the app-supported orientation mask to landscape-right while the tab is visible, and uses that same explicit capture orientation for both `AVCaptureVideoPreviewLayer` and movie output rotation.
 - New video walks should keep finished `.mov` files in app-managed local storage and persist the local `videoURL`; saving a copy to Photos is an explicit History detail action.
-- Deleting a recording removes app metadata, routes, and app-managed local video files; any user-exported Photos copy remains in Photos.
+- Route thumbnails are app-managed local image files generated after final save and persisted as `thumbnailURL`.
+- Deleting a recording removes app metadata, routes, app-managed thumbnails, and app-managed local video files; any user-exported Photos copy remains in Photos.
 - `WalkRecorder` also owns live heading updates for map-facing indicators while recording or previewing location.
 - Version 1 will render map overlays in the app instead of burning them into exported video.
 - App appearance is controlled by `AppTheme` in `@AppStorage`, defaulting to system appearance.
@@ -32,7 +33,8 @@ ASMR Walk is an iPhone walking journal. It will record GPS routes, optionally pa
 - Version 1 is intentionally iPhone-only; do not re-enable iPad as a targeted device family without a full adaptive-layout and App Store asset pass.
 - Version 1 is local-first with no developer-operated backend, accounts, analytics, advertising, or sync; App Privacy answers should be based on actual off-device collection, not protected APIs used only on device.
 - Finished recordings may receive best-effort generated place metadata after the final save; lookup failures must not block saving, and generated metadata must not overwrite user-edited titles or descriptions.
-- README, release checklist, privacy policy, and App Store copy must keep the same release scope language for device family, Photos ownership, background GPS, place metadata, and roadmap items.
+- Finished recordings may receive best-effort route thumbnails after the final save; thumbnail generation failures must not block saving.
+- README, release checklist, privacy policy, and App Store copy must keep the same release scope language for device family, Photos ownership, background GPS, route thumbnails, place metadata, and roadmap items.
 
 ## Conventions
 
@@ -41,6 +43,7 @@ ASMR Walk is an iPhone walking journal. It will record GPS routes, optionally pa
 - Keep recording state in dedicated observable types, not inside large SwiftUI views.
 - Use standard SwiftUI controls first so the interface follows the iOS 26 Liquid Glass system automatically.
 - Store video files in app-managed storage and persist their local URLs; Photos asset identifiers are export markers or legacy playback fallbacks, not the primary playback source.
+- Store route thumbnails as app-managed image files and persist only their local URLs in SwiftData.
 - Prompt on explicit stop before saving recordings shorter than 10 seconds; lifecycle interruptions should save automatically.
 - Starting a second recording mode while another is active should route the user back to the active recorder, not create another `WalkRecorder`.
 - Recording stop controls and live time/distance belong in the app-level active recording banner, not duplicated inside the Walk and Video Walk tabs.
@@ -69,7 +72,9 @@ Open the project in Xcode, select the `ASMR Walk` scheme, and run on an iPhone i
 - Disable the idle timer only while video recording is active, not for GPS-only walks.
 - Confirm that a video file exists before saving a video walk record; incomplete video sessions should not appear in history.
 - Delete messaging must distinguish app-managed local video files, which are removed with the recording, from any Photos copies, which remain in Photos.
+- Local recording cleanup should use `WalkRecordingLocalFiles` so app-managed thumbnails and videos are removed together.
 - MapKit reverse geocoding can suggest titles and descriptions after saving; cache rounded-coordinate results and treat the lookup as Apple framework behavior, not app-owned backend collection.
+- MapKit snapshots can generate route thumbnails after saving; treat map tile loading as Apple framework behavior, not app-owned backend collection.
 - Route points need accuracy and distance filtering before they affect distance totals or persistence.
 - Adding analytics, crash reporting SDKs, iCloud sync, accounts, remote storage, or any app-owned network upload requires revisiting `PrivacyInfo.xcprivacy`, App Privacy answers, and `PRIVACY_POLICY.md`.
 - Roadmap items must be labeled as future work in public docs, not mixed into implemented release capability lists.

--- a/APP_STORE_COPY.md
+++ b/APP_STORE_COPY.md
@@ -12,7 +12,7 @@ ASMR Walk is an iPhone walking journal for recording GPS routes, optional video 
 
 ASMR Walk helps you capture quiet walking memories on your iPhone. Record a GPS Walk for a simple route journal, or record a Video Walk when you want camera and microphone audio alongside the route.
 
-Saved walks stay local on your device. Video walks are stored in ASMR Walk for playback with the saved route, and you can save a copy to Photos from the History detail screen. After a walk is saved, ASMR Walk can use Apple Maps place information to suggest a useful title and description, which you can edit from the History detail screen. Deleting an ASMR Walk recording removes the route, app metadata, and app-managed video file, but it does not delete any copy you chose to save to Photos.
+Saved walks stay local on your device. Video walks are stored in ASMR Walk for playback with the saved route, and you can save a copy to Photos from the History detail screen. After a walk is saved, ASMR Walk can generate a route thumbnail and use Apple Maps place information to suggest a useful title and description, which you can edit from the History detail screen. Deleting an ASMR Walk recording removes the route, app metadata, app-managed thumbnail, and app-managed video file, but it does not delete any copy you chose to save to Photos.
 
 ASMR Walk can export full-fidelity GPX files through the iOS share sheet, including recording descriptions when present, and can create Google Maps walking-route links for quick sharing.
 
@@ -32,6 +32,6 @@ walking, GPS, route, GPX, video walk, walking journal, map, local-first
 - Finished video walks are stored locally in ASMR Walk by default.
 - Users can save a copy of a video walk to Photos from the History detail screen.
 - Deleting an ASMR Walk recording removes the app-managed local video but does not delete user-saved Photos copies.
-- ASMR Walk uses Apple MapKit reverse geocoding after saving a walk to suggest editable place-based titles and descriptions.
-- ASMR Walk stores route data, recording metadata, and app-managed videos locally and does not use developer-operated accounts, analytics, advertising, sync, or backend upload code in version 1.1.0.
+- ASMR Walk uses Apple MapKit after saving a walk to generate route thumbnails and suggest editable place-based titles and descriptions.
+- ASMR Walk stores route data, recording metadata, app-managed thumbnails, and app-managed videos locally and does not use developer-operated accounts, analytics, advertising, sync, or backend upload code in version 1.1.0.
 - The Settings screen includes a Privacy Policy link.

--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -14,6 +14,7 @@ struct HistoryView: View {
     @State private var recordingPendingDeletion: WalkRecording?
     @State private var deletionErrorMessage = ""
     @State private var isShowingDeletionError = false
+    @State private var thumbnailRefreshIDs: Set<UUID> = []
 
     init(startRecording: @escaping () -> Void = {}) {
         self.startRecording = startRecording
@@ -31,6 +32,9 @@ struct HistoryView: View {
             .navigationTitle("History")
             .navigationDestination(for: WalkRecording.self) { recording in
                 RecordingDetailView(recording: recording)
+            }
+            .task {
+                await refreshRouteThumbnails()
             }
             .alert("Delete Walk?", isPresented: deleteConfirmation) {
                 Button("Delete", role: .destructive) {
@@ -98,18 +102,35 @@ struct HistoryView: View {
         }
 
         let recordingID = recordingPendingDeletion.id
-        let videoURL = recordingPendingDeletion.videoURL
+        let removableURLs = WalkRecordingLocalFiles.removableURLs(for: recordingPendingDeletion)
         let persistence = WalkRecordingPersistence(modelContainer: modelContext.container)
 
         do {
             try await persistence.deleteRecording(id: recordingID)
-            if let videoURL {
-                try? FileManager.default.removeItem(at: videoURL)
+            for url in removableURLs {
+                try? FileManager.default.removeItem(at: url)
             }
             self.recordingPendingDeletion = nil
         } catch {
             deletionErrorMessage = error.localizedDescription
             isShowingDeletionError = true
+        }
+    }
+
+    private func refreshRouteThumbnails() async {
+        let modelContainer = modelContext.container
+        let snapshots = recordings.compactMap { recording -> WalkRecordingSnapshot? in
+            guard recording.needsRouteThumbnailRefresh,
+                  thumbnailRefreshIDs.contains(recording.id) == false else {
+                return nil
+            }
+
+            thumbnailRefreshIDs.insert(recording.id)
+            return recording.snapshotForThumbnailGeneration
+        }
+
+        for snapshot in snapshots {
+            await WalkRouteThumbnailGenerator.generate(for: snapshot, in: modelContainer)
         }
     }
 }
@@ -119,12 +140,7 @@ private struct RecordingRow: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            Image(systemName: recording.mode.systemImage)
-                .font(.title2)
-                .foregroundStyle(recording.hasVideo ? .red : .green)
-                .frame(width: 44, height: 44)
-                .background(.quaternary, in: .rect(cornerRadius: 12))
-                .accessibilityHidden(true)
+            RouteThumbnailView(recording: recording, size: CGSize(width: 64, height: 52))
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
@@ -153,5 +169,35 @@ private struct RecordingRow: View {
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .combine)
+    }
+}
+
+private extension WalkRecording {
+    var needsRouteThumbnailRefresh: Bool {
+        points.count > 1
+            && (thumbnailURL == nil || thumbnailStyleVersion < WalkRouteThumbnailGenerator.styleVersion)
+    }
+
+    var snapshotForThumbnailGeneration: WalkRecordingSnapshot {
+        WalkRecordingSnapshot(
+            id: id,
+            title: title,
+            createdAt: createdAt,
+            duration: duration,
+            distanceMeters: distanceMeters,
+            mode: mode,
+            videoURL: videoURL,
+            videoAssetIdentifier: videoAssetIdentifier,
+            points: pointsInTimeOrder.map { point in
+                LocationPointSnapshot(
+                    timestamp: point.timestamp,
+                    latitude: point.latitude,
+                    longitude: point.longitude,
+                    altitude: point.altitude,
+                    horizontalAccuracy: point.horizontalAccuracy,
+                    speed: point.speed
+                )
+            }
+        )
     }
 }

--- a/ASMR Walk/Features/History/RecordingDetailView.swift
+++ b/ASMR Walk/Features/History/RecordingDetailView.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import SwiftData
+import UIKit
 
 struct RecordingDetailView: View {
     @Environment(\.modelContext) private var modelContext
@@ -104,11 +105,20 @@ struct RecordingDetailView: View {
                         }
                     }
 
-                    ShareLink(
-                        item: routeExport.gpxFile,
-                        preview: SharePreview(recording.title, icon: Image(systemName: "map"))
-                    ) {
-                        Label("GPX Route File", systemImage: "point.topleft.down.to.point.bottomright.curvepath")
+                    if let thumbnailImage {
+                        ShareLink(
+                            item: routeExport.gpxFile,
+                            preview: SharePreview(recording.title, image: Image(uiImage: thumbnailImage))
+                        ) {
+                            Label("GPX Route File", systemImage: "point.topleft.down.to.point.bottomright.curvepath")
+                        }
+                    } else {
+                        ShareLink(
+                            item: routeExport.gpxFile,
+                            preview: SharePreview(recording.title, icon: Image(systemName: "map"))
+                        ) {
+                            Label("GPX Route File", systemImage: "point.topleft.down.to.point.bottomright.curvepath")
+                        }
                     }
                 }
                 .disabled(recording.points.isEmpty)
@@ -120,6 +130,14 @@ struct RecordingDetailView: View {
 
     private var routeExport: WalkRouteExport {
         WalkRouteExport(recording: recording)
+    }
+
+    private var thumbnailImage: UIImage? {
+        guard let thumbnailURL = recording.thumbnailURL else {
+            return nil
+        }
+
+        return UIImage(contentsOfFile: thumbnailURL.path)
     }
 
     private var recordingMetadataCard: some View {
@@ -138,6 +156,8 @@ struct RecordingDetailView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
+                RouteThumbnailView(recording: recording, size: CGSize(width: 128, height: 88))
+
                 Text(recording.title)
                     .font(.title3.weight(.semibold))
 

--- a/ASMR Walk/Features/History/RouteThumbnailView.swift
+++ b/ASMR Walk/Features/History/RouteThumbnailView.swift
@@ -1,0 +1,50 @@
+//
+//  RouteThumbnailView.swift
+//  ASMR Walk
+//
+
+import SwiftUI
+import UIKit
+
+struct RouteThumbnailView: View {
+    let recording: WalkRecording
+    let size: CGSize
+
+    var body: some View {
+        Group {
+            if let image = thumbnailImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                fallback
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipShape(.rect(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.primary.opacity(0.12), lineWidth: 1)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var thumbnailImage: UIImage? {
+        guard let thumbnailURL = recording.thumbnailURL else {
+            return nil
+        }
+
+        return UIImage(contentsOfFile: thumbnailURL.path)
+    }
+
+    private var fallback: some View {
+        ZStack {
+            Rectangle()
+                .fill(.quaternary)
+
+            Image(systemName: recording.mode.systemImage)
+                .font(.title2)
+                .foregroundStyle(recording.hasVideo ? .red : .green)
+        }
+    }
+}

--- a/ASMR Walk/Features/Walk/WalkRecorder.swift
+++ b/ASMR Walk/Features/Walk/WalkRecorder.swift
@@ -369,7 +369,9 @@ final class WalkRecorder: NSObject {
             reset()
             if let modelContainer {
                 Task {
-                    await WalkRecordingMetadataGenerator.generate(for: snapshot, in: modelContainer)
+                    async let metadataGeneration: Void = WalkRecordingMetadataGenerator.generate(for: snapshot, in: modelContainer)
+                    async let thumbnailGeneration: Void = WalkRouteThumbnailGenerator.generate(for: snapshot, in: modelContainer)
+                    _ = await (metadataGeneration, thumbnailGeneration)
                 }
             }
         } catch {

--- a/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
@@ -60,6 +60,16 @@ actor WalkRecordingPersistence {
         try modelContext.save()
     }
 
+    func updateThumbnailURL(recordingID: UUID, thumbnailURL: URL, styleVersion: Int) throws {
+        guard let recording = try fetchRecording(id: recordingID) else {
+            return
+        }
+
+        recording.thumbnailURL = thumbnailURL
+        recording.thumbnailStyleVersion = styleVersion
+        try modelContext.save()
+    }
+
     private func recording(for snapshot: WalkRecordingSnapshot) throws -> WalkRecording {
         if let recording = try fetchRecording(id: snapshot.id) {
             return recording

--- a/ASMR Walk/Features/Walk/WalkRouteThumbnailGenerator.swift
+++ b/ASMR Walk/Features/Walk/WalkRouteThumbnailGenerator.swift
@@ -1,0 +1,143 @@
+//
+//  WalkRouteThumbnailGenerator.swift
+//  ASMR Walk
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+import SwiftData
+import UIKit
+
+@MainActor
+enum WalkRouteThumbnailGenerator {
+    nonisolated static let styleVersion = 1
+    static let thumbnailSize = CGSize(width: 320, height: 220)
+    static let thumbnailCompressionQuality: CGFloat = 0.82
+
+    static func generate(
+        for snapshot: WalkRecordingSnapshot,
+        in modelContainer: ModelContainer,
+        fileManager: FileManager = .default
+    ) async {
+        guard snapshot.points.count > 1 else {
+            return
+        }
+
+        do {
+            let image = try await image(for: snapshot.points)
+            let thumbnailURL = try write(image: image, recordingID: snapshot.id, fileManager: fileManager)
+            let persistence = WalkRecordingPersistence(modelContainer: modelContainer)
+            try await persistence.updateThumbnailURL(
+                recordingID: snapshot.id,
+                thumbnailURL: thumbnailURL,
+                styleVersion: styleVersion
+            )
+        } catch {
+            // Thumbnail generation is best-effort and must never block or undo a saved recording.
+        }
+    }
+
+    static func thumbnailDirectory(fileManager: FileManager = .default) throws -> URL {
+        let directory = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        .appending(path: "Route Thumbnails", directoryHint: .isDirectory)
+
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    static func thumbnailURL(recordingID: UUID, fileManager: FileManager = .default) throws -> URL {
+        try thumbnailDirectory(fileManager: fileManager)
+            .appending(path: "\(recordingID.uuidString).jpg")
+    }
+
+    private static func image(for points: [LocationPointSnapshot]) async throws -> UIImage {
+        let coordinates = points.map(\.coordinate)
+        let options = MKMapSnapshotter.Options()
+        options.size = thumbnailSize
+        options.mapType = .standard
+        options.region = region(for: coordinates)
+
+        let snapshot = try await MKMapSnapshotter(options: options).start()
+        return drawRoute(coordinates, on: snapshot)
+    }
+
+    private static func write(
+        image: UIImage,
+        recordingID: UUID,
+        fileManager: FileManager
+    ) throws -> URL {
+        let url = try thumbnailURL(recordingID: recordingID, fileManager: fileManager)
+        guard let data = image.jpegData(compressionQuality: thumbnailCompressionQuality) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private static func region(for coordinates: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
+        let mapRect = coordinates
+            .map { MKMapRect(origin: MKMapPoint($0), size: MKMapSize(width: 0, height: 0)) }
+            .reduce(MKMapRect.null) { partialResult, mapRect in
+                partialResult.union(mapRect)
+            }
+
+        let paddedRect = mapRect.insetBy(dx: -max(mapRect.width * 0.18, 800), dy: -max(mapRect.height * 0.18, 800))
+        return MKCoordinateRegion(paddedRect)
+    }
+
+    private static func drawRoute(
+        _ coordinates: [CLLocationCoordinate2D],
+        on snapshot: MKMapSnapshotter.Snapshot
+    ) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = snapshot.image.scale
+
+        return UIGraphicsImageRenderer(size: snapshot.image.size, format: format).image { context in
+            snapshot.image.draw(at: .zero)
+
+            let path = UIBezierPath()
+            for (index, coordinate) in coordinates.enumerated() {
+                let point = snapshot.point(for: coordinate)
+                if index == 0 {
+                    path.move(to: point)
+                } else {
+                    path.addLine(to: point)
+                }
+            }
+
+            UIColor.systemGreen.withAlphaComponent(0.28).setStroke()
+            path.lineWidth = 10
+            path.lineCapStyle = .round
+            path.lineJoinStyle = .round
+            path.stroke()
+
+            UIColor.systemGreen.setStroke()
+            path.lineWidth = 5
+            path.stroke()
+
+            if let firstCoordinate = coordinates.first {
+                drawEndpoint(at: snapshot.point(for: firstCoordinate), color: .systemGreen, in: context.cgContext)
+            }
+
+            if let lastCoordinate = coordinates.last {
+                drawEndpoint(at: snapshot.point(for: lastCoordinate), color: .systemRed, in: context.cgContext)
+            }
+        }
+    }
+
+    private static func drawEndpoint(at point: CGPoint, color: UIColor, in context: CGContext) {
+        let rect = CGRect(x: point.x - 5, y: point.y - 5, width: 10, height: 10)
+        context.setFillColor(color.cgColor)
+        context.fillEllipse(in: rect)
+        context.setStrokeColor(UIColor.white.cgColor)
+        context.setLineWidth(2)
+        context.strokeEllipse(in: rect)
+    }
+}

--- a/ASMR Walk/Models/WalkRecording+Presentation.swift
+++ b/ASMR Walk/Models/WalkRecording+Presentation.swift
@@ -37,6 +37,14 @@ extension WalkRecording {
 
         return FileManager.default.fileExists(atPath: videoURL.path)
     }
+
+    var localThumbnailFileExists: Bool {
+        guard let thumbnailURL else {
+            return false
+        }
+
+        return FileManager.default.fileExists(atPath: thumbnailURL.path)
+    }
 }
 
 extension TimeInterval {
@@ -58,5 +66,11 @@ extension Double {
     var distanceText: String {
         Measurement(value: max(0, self), unit: UnitLength.meters)
             .formatted(.measurement(width: .abbreviated, usage: .road))
+    }
+}
+
+enum WalkRecordingLocalFiles {
+    static func removableURLs(for recording: WalkRecording) -> [URL] {
+        [recording.videoURL, recording.thumbnailURL].compactMap { $0 }
     }
 }

--- a/ASMR Walk/Models/WalkRecording.swift
+++ b/ASMR Walk/Models/WalkRecording.swift
@@ -26,6 +26,8 @@ final class WalkRecording {
     var isDescriptionUserEdited: Bool
     var videoURL: URL?
     var videoAssetIdentifier: String?
+    var thumbnailURL: URL?
+    var thumbnailStyleVersion: Int
 
     @Relationship(deleteRule: .cascade, inverse: \LocationPoint.recording)
     var points: [LocationPoint]
@@ -44,6 +46,8 @@ final class WalkRecording {
         isDescriptionUserEdited: Bool = false,
         videoURL: URL? = nil,
         videoAssetIdentifier: String? = nil,
+        thumbnailURL: URL? = nil,
+        thumbnailStyleVersion: Int = 0,
         points: [LocationPoint] = []
     ) {
         self.id = id
@@ -59,6 +63,8 @@ final class WalkRecording {
         self.isDescriptionUserEdited = isDescriptionUserEdited
         self.videoURL = videoURL
         self.videoAssetIdentifier = videoAssetIdentifier
+        self.thumbnailURL = thumbnailURL
+        self.thumbnailStyleVersion = thumbnailStyleVersion
         self.points = points
     }
 

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -629,6 +629,8 @@ struct WalkRecordingTests {
         #expect(recording.metadataGeneratedAt == nil)
         #expect(recording.isTitleUserEdited == false)
         #expect(recording.isDescriptionUserEdited == false)
+        #expect(recording.thumbnailURL == nil)
+        #expect(recording.thumbnailStyleVersion == 0)
         #expect(recording.points.isEmpty)
         #expect(recording.hasVideo == false)
     }
@@ -660,6 +662,20 @@ struct WalkRecordingTests {
 
         #expect(walk.hasVideo == false)
         #expect(videoWalk.hasVideo)
+    }
+
+    @Test("Local file cleanup includes video and thumbnail assets")
+    func localFileCleanupIncludesVideoAndThumbnailAssets() {
+        let videoURL = URL(filePath: "/tmp/video.mov")
+        let thumbnailURL = URL(filePath: "/tmp/thumbnail.jpg")
+        let recording = WalkRecording(
+            title: "Video Walk",
+            mode: .videoWalk,
+            videoURL: videoURL,
+            thumbnailURL: thumbnailURL
+        )
+
+        #expect(WalkRecordingLocalFiles.removableURLs(for: recording) == [videoURL, thumbnailURL])
     }
 
     @Test("Short recordings use a 10 second save confirmation threshold")
@@ -1038,6 +1054,42 @@ struct WalkRecordingTests {
         #expect(updatedRecording.walkDescription == "Generated description.")
         #expect(updatedRecording.generatedPlaceName == "Papago Park")
         #expect(updatedRecording.metadataGeneratedAt == generatedAt)
+    }
+
+    @Test("Persistence stores generated route thumbnail URLs")
+    func persistenceStoresGeneratedRouteThumbnailURLs() async throws {
+        let recordingID = try #require(UUID(uuidString: "CC9044A6-89AF-4BA9-9B8F-C4CC25E4313F"))
+        let thumbnailURL = URL(filePath: "/tmp/route-thumbnail.jpg")
+        let container = try makeContainer()
+        let persistence = WalkRecordingPersistence(modelContainer: container)
+        let snapshot = makeSnapshot(
+            id: recordingID,
+            title: "Thumbnail Walk",
+            duration: 75,
+            distanceMeters: 210,
+            pointCount: 8
+        )
+
+        try await persistence.save(snapshot)
+        try await persistence.updateThumbnailURL(
+            recordingID: recordingID,
+            thumbnailURL: thumbnailURL,
+            styleVersion: WalkRouteThumbnailGenerator.styleVersion
+        )
+
+        let recording = try #require(try fetchRecording(id: recordingID, in: container))
+        #expect(recording.thumbnailURL == thumbnailURL)
+        #expect(recording.thumbnailStyleVersion == WalkRouteThumbnailGenerator.styleVersion)
+    }
+
+    @Test("Route thumbnail filenames are tied to recording IDs")
+    func routeThumbnailFilenamesAreTiedToRecordingIDs() throws {
+        let recordingID = try #require(UUID(uuidString: "C88807DA-8957-4B6F-A6C7-1D1C37BA9515"))
+        let url = try WalkRouteThumbnailGenerator.thumbnailURL(recordingID: recordingID)
+
+        #expect(WalkRouteThumbnailGenerator.styleVersion == 1)
+        #expect(url.lastPathComponent == "\(recordingID.uuidString).jpg")
+        #expect(url.deletingLastPathComponent().lastPathComponent == "Route Thumbnails")
     }
 
     @Test("Sample data contains both recording modes")

--- a/Journal.md
+++ b/Journal.md
@@ -345,6 +345,14 @@ The important engineering move is that metadata generation is a guest, not the l
 
 SwiftData had its own small trap here: an `@Model` cannot use a stored property named `description`, so the model stores the field as `walkDescription`. GPX export now includes that text in both standard `<desc>` elements and ASMR Walk extensions, which means the friendly label travels with the route when the user chooses to share it.
 
+### Thumbnails Are Tiny Trail Postcards
+
+Issue 47 gives History a visual memory. A list of walk titles and dates is useful, but a small route thumbnail works like a postcard tucked into the journal: one glance tells you whether this was the canal loop, the park lap, or the wandering zigzag that happened because the coffee shop was closed.
+
+The thumbnail generator follows the same rule as place metadata: save the walk first, then do the decorative work. `MKMapSnapshotter` captures the map image, ASMR Walk draws the recorded route and endpoints over it, and the finished JPEG lands in app-managed storage while SwiftData keeps only the local `thumbnailURL`. If MapKit cannot render a snapshot, the recording still saves and the UI falls back to the familiar mode icon.
+
+Cleanup needed its own little checklist. Video files and thumbnails are both app-managed local files, so deletion now asks `WalkRecordingLocalFiles` for everything that belongs to the recording and removes those files after SwiftData deletes the row. The route stays local-first, the thumbnail stays lightweight, and no one has to wonder why a deleted walk left a tiny souvenir behind.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -6,7 +6,7 @@ ASMR Walk is designed as a local-first walking journal. The app records walking 
 
 ## Data Stored On Your Device
 
-ASMR Walk stores walk titles, editable walk descriptions, dates, durations, distances, and route points locally on your device using Apple's local persistence frameworks.
+ASMR Walk stores walk titles, editable walk descriptions, dates, durations, distances, route thumbnails, and route points locally on your device using Apple's local persistence frameworks.
 
 Route points can include latitude, longitude, timestamp, altitude when available, horizontal accuracy, and speed when available. This data stays on your device unless you choose to export or share it.
 
@@ -16,7 +16,7 @@ ASMR Walk uses location while recording to draw and save your walking route.
 
 Background GPS recording is optional, applies only to GPS Walk recordings, and requires Always location permission. When enabled, ASMR Walk may continue recording a GPS-only walk while the app is backgrounded or the screen is locked. Video Walks do not continue recording in the background.
 
-After a recording is saved, ASMR Walk may use Apple's MapKit reverse-geocoding service to suggest a place-based title and description. This lookup is best-effort and is used only to improve the local recording details shown in the app.
+After a recording is saved, ASMR Walk may use Apple's MapKit services to generate a route thumbnail and suggest a place-based title and description. This work is best-effort and is used only to improve the local recording details shown in the app.
 
 ## Camera And Microphone
 
@@ -26,7 +26,7 @@ ASMR Walk uses the camera and microphone only for Video Walk recording. Video ca
 
 ASMR Walk keeps newly recorded video walks in app-managed local storage for playback with your saved route. From a video walk's History detail screen, you can choose to save a copy of that local video to your Photos library.
 
-Deleting an ASMR Walk recording removes the app's route, metadata, and app-managed video file. It does not delete any copy you chose to save to Photos. ASMR Walk may still read older Photos-backed video walks created by earlier versions so they can replay with their saved routes.
+Deleting an ASMR Walk recording removes the app's route, metadata, app-managed thumbnail, and app-managed video file. It does not delete any copy you chose to save to Photos. ASMR Walk may still read older Photos-backed video walks created by earlier versions so they can replay with their saved routes.
 
 Photos may use Apple's own services, such as iCloud Photos, depending on your device settings. ASMR Walk does not operate those services.
 
@@ -43,7 +43,7 @@ Sharing is user-initiated through the iOS share sheet. The destination you choos
 
 ASMR Walk does not make direct app-owned network requests for analytics, accounts, syncing, advertising, or server storage.
 
-Some Apple frameworks or user-selected destinations may contact network services outside ASMR Walk's control. Examples include MapKit reverse geocoding a saved route point, Photos loading an iCloud-backed video asset, or the user opening a Google Maps route link.
+Some Apple frameworks or user-selected destinations may contact network services outside ASMR Walk's control. Examples include MapKit loading map imagery or reverse geocoding a saved route point, Photos loading an iCloud-backed video asset, or the user opening a Google Maps route link.
 
 ## Tracking
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ASMR Walk is an iPhone walking journal built with SwiftUI. It records GPS walkin
 
 ## Version 1.1.0 Scope
 
-ASMR Walk 1.1.0 is intentionally iPhone-only and local-first. It supports GPS Walk recordings, Video Walk recordings, optional background GPS for GPS Walk only, local video storage with user-initiated Photos export, local history, generated place-based recording details, and route export. It does not include iPad support, Apple Watch, HealthKit, iCloud sync, analytics, accounts, advertising, or a developer-operated backend.
+ASMR Walk 1.1.0 is intentionally iPhone-only and local-first. It supports GPS Walk recordings, Video Walk recordings, optional background GPS for GPS Walk only, local video storage with user-initiated Photos export, local history, route thumbnails, generated place-based recording details, and route export. It does not include iPad support, Apple Watch, HealthKit, iCloud sync, analytics, accounts, advertising, or a developer-operated backend.
 
 ## Current Features
 
@@ -15,8 +15,9 @@ ASMR Walk 1.1.0 is intentionally iPhone-only and local-first. It supports GPS Wa
 - Saved video walk playback with a synchronized route-progress map overlay.
 - Local persistence with SwiftData.
 - Recording detail screens with editable titles and descriptions, route maps, duration, distance, route-point counts, and video indicators.
+- Generated route thumbnails for saved walks in History, detail views, and GPX share previews.
 - Best-effort place metadata generation after saving a walk, with fallback date/time titles when lookup is unavailable.
-- Delete support for saved recordings. App-managed video files are removed with their recording; any user-saved Photos copies remain in Photos.
+- Delete support for saved recordings. App-managed video and thumbnail files are removed with their recording; any user-saved Photos copies remain in Photos.
 - Route export through the iOS share sheet.
 - Google Maps walking-route URL export.
 - GPX file export for higher-fidelity route sharing, including recording descriptions when present.
@@ -79,7 +80,7 @@ Finished video walks are kept in ASMR Walk's app-managed storage for playback. F
 
 ## Privacy
 
-ASMR Walk is local-first. The app does not include developer-operated accounts, analytics, advertising, sync, or backend upload code. Route data, recording metadata, and video references stay on the device unless the user saves video to Photos or explicitly exports or shares a route. After saving, ASMR Walk may ask Apple's MapKit reverse-geocoding service for a place name so it can suggest a useful title and description.
+ASMR Walk is local-first. The app does not include developer-operated accounts, analytics, advertising, sync, or backend upload code. Route data, recording metadata, route thumbnails, and video references stay on the device unless the user saves video to Photos or explicitly exports or shares a route. After saving, ASMR Walk may ask Apple's MapKit services for map imagery and a place name so it can generate a route thumbnail and suggest a useful title and description.
 
 See `PRIVACY_POLICY.md` for the public privacy-policy source. Before App Store submission, publish that policy at a stable URL and enter the URL in App Store Connect.
 
@@ -103,6 +104,7 @@ The unit test suite covers:
 - Tab metadata.
 - SwiftData recording lifecycle.
 - Generated and editable recording metadata.
+- Route thumbnail path and persistence helpers.
 - GPS route filtering and distance accumulation.
 - Video-walk recording metadata.
 - Google Maps route export.
@@ -124,7 +126,6 @@ The app uses a native static launch screen configured through the target Info se
 These are future ideas, not shipped 1.1.0 features:
 
 - iCloud sync.
-- Route thumbnails.
 - HealthKit workout integration.
 - Apple Watch companion recording.
 - Burned-in video map overlay export.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -52,6 +52,9 @@ Run these on a physical iPhone before submission:
 ### Physical Device Only
 
 - [ ] Start and save a GPS-only walk.
+- [ ] Confirm a saved GPS-only walk receives a route thumbnail in History and on the detail screen.
+- [ ] Confirm a saved video walk receives a route thumbnail while local video playback still works.
+- [ ] Confirm thumbnail generation failures leave the recording saved and usable.
 - [ ] Confirm a saved GPS-only walk receives a useful place-based title and editable description when MapKit reverse geocoding succeeds.
 - [ ] Confirm a saved walk keeps its fallback date/time title when place lookup fails or returns no usable place name.
 - [ ] Edit a saved recording title and description from History detail, leave and reopen the detail screen, and confirm the edits persist.
@@ -90,6 +93,7 @@ Run these on a physical iPhone before submission:
 - [ ] Run Accessibility Inspector on Walk, Video Walk, History, and Settings. Resolve or document any remaining issues.
 - [ ] Open a saved video walk and confirm playback plus route overlay works.
 - [ ] Delete a video walk and confirm the app recording and local video file are removed. User-saved Photos copies should remain in Photos unless a separate delete-from-Photos feature is added.
+- [ ] Delete a recording with a route thumbnail and confirm the app-managed thumbnail file is removed.
 - [ ] Export a Google Maps URL.
 - [ ] Export a GPX file through the share sheet.
 - [ ] Inspect an exported GPX file and confirm ASMR Walk extensions include duration, recording mode, `hasVideo`, recording ID, horizontal accuracy, and speed when available.
@@ -112,12 +116,13 @@ Run these on a physical iPhone before submission:
 - [ ] Document network behavior: no direct app-owned network calls, no analytics SDK, no account backend, no CloudKit sync.
 - [ ] Document user-initiated sharing: GPX exports and Google Maps route links may send route data to the user's chosen share destination.
 - [ ] Document Apple framework behavior separately: Photos may use iCloud Photos for copies the user saves or older Photos-backed videos.
-- [ ] Document Apple framework behavior separately: MapKit may reverse geocode a saved route point to suggest editable titles and descriptions.
+- [ ] Document Apple framework behavior separately: MapKit may load map imagery for route thumbnails and reverse geocode a saved route point to suggest editable titles and descriptions.
 - [ ] Confirm the app describes background GPS recording as optional and user-enabled.
 - [ ] Confirm App Store copy says ASMR Walk 1.1.0 is iPhone-only.
 - [ ] Include review notes that background location is GPS Walk only, requires the user to enable Background GPS Recording in Settings, and requires Always location permission.
 - [ ] Include screenshots for History, Walk, Video Walk, Recording Detail, and Settings.
 - [ ] Mention that route data is stored locally.
+- [ ] Mention that route thumbnails are stored locally.
 - [ ] Mention that video walks are stored locally in ASMR Walk by default.
 - [ ] Mention that users can save a copy of a video walk to Photos from History detail.
 - [ ] Mention that deleting an ASMR Walk recording removes the app-managed local video but does not delete user-saved Photos copies.


### PR DESCRIPTION
## Summary

- Generate local MapKit route thumbnails after a recording is saved without blocking the save flow.
- Show thumbnails in History rows, detail metadata, and GPX share previews with a mode-icon fallback.
- Persist thumbnail URLs and style versions, regenerate stale/missing thumbnails from History, and remove thumbnail files with recording cleanup.
- Update release docs, privacy copy, project memory, and tests for the new local thumbnail behavior.

## Validation

- Xcode BuildProject: passed
- Focused thumbnail tests: 4 passed
- Unit test chunks: 69 tests passed
- UI test chunks: 17 tests passed, including launch performance
- RunAllTests attempted, but the MCP tool timed out at 120 seconds before returning results; the same active test plan was then run successfully in smaller chunks.

Closes #47
