### PR TITLE
Fix beta bugs: history delete, video save message, and crash (#54 #55)

### DIFF
--- a/ASMR Walk/ContentView.swift
+++ b/ASMR Walk/ContentView.swift
@@ -47,6 +47,8 @@ enum AccessibilityID {
     static let onboardingWalkPage = "onboarding.page.walk"
     static let onboardingVideoWalkPage = "onboarding.page.videoWalk"
     static let onboardingHistoryPage = "onboarding.page.history"
+    static let onboardingDeleteHistoryPage = "onboarding.page.deleteHistory"
+    static let onboardingBackgroundGPSPage = "onboarding.page.backgroundGPS"
     static let onboardingPrimaryButton = "onboarding.primaryButton"
     static let onboardingSkipButton = "onboarding.skipButton"
     static let historyEmptyState = "history.emptyState"

--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -34,9 +34,7 @@ struct HistoryView: View {
             }
             .alert("Delete Walk?", isPresented: deleteConfirmation) {
                 Button("Delete", role: .destructive) {
-                    Task {
-                        await deletePendingRecording()
-                    }
+                    deletePendingRecording()
                 }
                 Button("Cancel", role: .cancel) {
                     recordingPendingDeletion = nil
@@ -92,17 +90,15 @@ struct HistoryView: View {
         )
     }
 
-    private func deletePendingRecording() async {
+    private func deletePendingRecording() {
         guard let recordingPendingDeletion else {
             return
         }
 
-        let recordingID = recordingPendingDeletion.id
         let videoURL = recordingPendingDeletion.videoURL
-        let persistence = WalkRecordingPersistence(modelContainer: modelContext.container)
-
         do {
-            try await persistence.deleteRecording(id: recordingID)
+            modelContext.delete(recordingPendingDeletion)
+            try modelContext.save()
             if let videoURL {
                 try? FileManager.default.removeItem(at: videoURL)
             }

--- a/ASMR Walk/Features/Onboarding/OnboardingView.swift
+++ b/ASMR Walk/Features/Onboarding/OnboardingView.swift
@@ -76,6 +76,8 @@ private enum OnboardingPage: CaseIterable, Identifiable {
     case walk
     case videoWalk
     case history
+    case deleteHistory
+    case backgroundGPS
 
     var id: Self { self }
 
@@ -87,6 +89,10 @@ private enum OnboardingPage: CaseIterable, Identifiable {
             "Video Walk"
         case .history:
             "History"
+        case .deleteHistory:
+            "Deleting Walks"
+        case .backgroundGPS:
+            "Background GPS"
         }
     }
 
@@ -98,6 +104,10 @@ private enum OnboardingPage: CaseIterable, Identifiable {
             "Capture video while ASMR Walk tracks the route beside it. Finished videos stay in the app, and you can save a copy to Photos from History."
         case .history:
             "Review saved walks, replay routes on the map, watch video walks, and export GPX files when you need the route elsewhere."
+        case .deleteHistory:
+            "To remove a walk from History, swipe left on it and tap Delete. A confirmation will appear before anything is permanently removed."
+        case .backgroundGPS:
+            "GPS walks keep recording even when you leave the app. Enable \"Always\" location access in Settings → Privacy & Security → Location Services → ASMR Walk to ensure your route is captured the whole way."
         }
     }
 
@@ -109,6 +119,10 @@ private enum OnboardingPage: CaseIterable, Identifiable {
             "video.fill"
         case .history:
             "clock.arrow.circlepath"
+        case .deleteHistory:
+            "trash.circle"
+        case .backgroundGPS:
+            "location.circle"
         }
     }
 
@@ -120,6 +134,10 @@ private enum OnboardingPage: CaseIterable, Identifiable {
             .blue
         case .history:
             .indigo
+        case .deleteHistory:
+            .red
+        case .backgroundGPS:
+            .teal
         }
     }
 
@@ -131,6 +149,10 @@ private enum OnboardingPage: CaseIterable, Identifiable {
             AccessibilityID.onboardingVideoWalkPage
         case .history:
             AccessibilityID.onboardingHistoryPage
+        case .deleteHistory:
+            AccessibilityID.onboardingDeleteHistoryPage
+        case .backgroundGPS:
+            AccessibilityID.onboardingBackgroundGPSPage
         }
     }
 }

--- a/ASMR Walk/Features/Video/CameraPreview.swift
+++ b/ASMR Walk/Features/Video/CameraPreview.swift
@@ -20,6 +20,12 @@ struct CameraPreview: UIViewRepresentable {
     func updateUIView(_ uiView: PreviewView, context: Context) {
         uiView.configure(session: session, videoRotationAngle: videoRotationAngle)
     }
+
+    static func dismantleUIView(_ uiView: PreviewView, coordinator: ()) {
+        // Detach before dealloc — AVCaptureSession asserts if the preview
+        // layer is still connected when the session's ref count hits zero.
+        uiView.previewLayer.session = nil
+    }
 }
 
 final class PreviewView: UIView {

--- a/ASMR Walk/Features/Video/VideoCaptureService.swift
+++ b/ASMR Walk/Features/Video/VideoCaptureService.swift
@@ -70,6 +70,7 @@ final class VideoCaptureService: NSObject {
     private(set) var isReady = false
     private(set) var isRecording = false
     private(set) var errorMessage: String?
+    private(set) var successMessage: String?
     private(set) var cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
     private(set) var microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
 
@@ -184,6 +185,7 @@ final class VideoCaptureService: NSObject {
         movieOutput.startRecording(to: url, recordingDelegate: self)
         isRecording = true
         errorMessage = nil
+        successMessage = nil
     }
 
     func report(_ error: Error) {
@@ -191,11 +193,11 @@ final class VideoCaptureService: NSObject {
     }
 
     func reportMessage(_ message: String) {
-        errorMessage = message
+        successMessage = message
     }
 
     func stopRecording() async throws -> URL {
-        guard movieOutput.isRecording else {
+        guard movieOutput.isRecording, stopContinuation == nil else {
             throw CaptureError.notReady
         }
 

--- a/ASMR Walk/Features/Video/VideoWalkView.swift
+++ b/ASMR Walk/Features/Video/VideoWalkView.swift
@@ -186,7 +186,7 @@ struct VideoWalkView: View {
     }
 
     private var shouldShowStatusCard: Bool {
-        shouldShowRecordingIndicator == false || isStopping || camera.errorMessage != nil || walkRecorder.errorMessage != nil
+        shouldShowRecordingIndicator == false || isStopping || camera.errorMessage != nil || walkRecorder.errorMessage != nil || camera.successMessage != nil
     }
 
     private var recordingIndicator: some View {
@@ -298,6 +298,9 @@ struct VideoWalkView: View {
         if isRecordingVideoWalk {
             return "Recording video walk"
         }
+        if camera.successMessage != nil {
+            return "Video walk saved"
+        }
         if camera.errorMessage != nil || walkRecorder.errorMessage != nil {
             return "Video unavailable"
         }
@@ -323,6 +326,9 @@ struct VideoWalkView: View {
             return "Enable camera, microphone, and location access in Settings to record a video walk."
         }
 
+        if let successMessage = camera.successMessage {
+            return successMessage
+        }
         if let errorMessage = camera.errorMessage ?? walkRecorder.errorMessage {
             return errorMessage
         }


### PR DESCRIPTION
## Summary

Fixes three beta bugs reported against the 1.0 TestFlight build (Release-v1).

### #54 — History swipe-delete has no effect
- `deletePendingRecording()` was using a separate `WalkRecordingPersistence` @ModelActor with its own context; the view's `@Query` never observed deletions made in a different context, so rows stayed on screen
- Fix: delete directly on the view's own `modelContext` — `modelContext.delete(recording); try modelContext.save()` — guaranteeing the `@Query` refreshes immediately

### #54 — Onboarding missing delete and background-GPS instructions
- Added two new `OnboardingPage` cases: `.deleteHistory` (swipe-left instruction) and `.backgroundGPS` (explains the "Always" location permission needed for background recording)
- Added corresponding `AccessibilityID` constants

### #55 — "Video unavailable" shown after a successful save
- `VideoCaptureService.reportMessage(_:)` was writing to `errorMessage`, so a successful save message (`"Video walk saved in ASMR Walk."`) caused `VideoWalkView.statusTitle` to return `"Video unavailable"`
- Fix: added a separate `successMessage` property; `reportMessage` now sets `successMessage`; `VideoWalkView` shows `"Video walk saved"` title when `successMessage != nil`

### #55 — App crash (TestFlight Aug 16 2026 6:41 PM)
- **Root cause from crash log**: `EXC_CRASH SIGABRT` — `AVCaptureVideoPreviewLayer.detachFromFigCaptureSession:` assertion fired because `AVCaptureSession` was dealloc'd while the preview layer was still attached
- `CameraPreview` (`UIViewRepresentable`) had no `dismantleUIView` — when SwiftUI removed the view, `previewLayer.session` was never cleared, so the session's Swift ref-count hit zero mid-dealloc with the layer still connected
- Fix: added `dismantleUIView` to nil out `previewLayer.session` before the view is torn down

Also added a guard in `VideoCaptureService.stopRecording()` to prevent a second concurrent call from overwriting an in-flight `CheckedContinuation`.

## Test plan

- [ ] Swipe left on a history item → tap Delete → confirm item disappears immediately (no ghost row after restart)
- [ ] Reset onboarding (Settings → Show Onboarding) → verify two new pages appear: swipe-to-delete and background GPS
- [ ] Record a video walk → stop it → confirm status shows **"Video walk saved"**, not "Video unavailable"
- [ ] Record and stop multiple video walks in succession — no crash on stop or when navigating away from the video tab
- [ ] Background GPS walk — leave app mid-recording — confirm route is captured on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)