### PR TITLE
Update contact email to support@bald-traveler.com

### DIFF
--- a/ASMR Walk/Features/Settings/SettingsView.swift
+++ b/ASMR Walk/Features/Settings/SettingsView.swift
@@ -89,7 +89,7 @@ struct AboutInfo: Equatable {
                 ?? "ASMR Walk",
             version: dictionary["CFBundleShortVersionString"] as? String ?? "Unknown",
             build: dictionary["CFBundleVersion"] as? String ?? "Unknown",
-            contactEmail: "heathdj@me.com"
+            contactEmail: "support@bald-traveler.com"
         )
     }
 }


### PR DESCRIPTION
Replaces the personal iCloud address with the dedicated support email.

Same change already applied to `main` (cfa5292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)