### PR TITLE
Fix 1.1 QA issues: async thumbnail load, parallel backfill, dead field

### DIFF
--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -125,8 +125,12 @@ struct HistoryView: View {
             return recording.snapshotForThumbnailGeneration
         }
 
-        for snapshot in snapshots {
-            await WalkRouteThumbnailGenerator.generate(for: snapshot, in: modelContainer)
+        await withTaskGroup(of: Void.self) { group in
+            for snapshot in snapshots {
+                group.addTask {
+                    await WalkRouteThumbnailGenerator.generate(for: snapshot, in: modelContainer)
+                }
+            }
         }
     }
 }

--- a/ASMR Walk/Features/History/RouteThumbnailView.swift
+++ b/ASMR Walk/Features/History/RouteThumbnailView.swift
@@ -10,9 +10,11 @@ struct RouteThumbnailView: View {
     let recording: WalkRecording
     let size: CGSize
 
+    @State private var image: UIImage?
+
     var body: some View {
         Group {
-            if let image = thumbnailImage {
+            if let image {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFill()
@@ -27,14 +29,16 @@ struct RouteThumbnailView: View {
                 .stroke(.primary.opacity(0.12), lineWidth: 1)
         }
         .accessibilityHidden(true)
-    }
-
-    private var thumbnailImage: UIImage? {
-        guard let thumbnailURL = recording.thumbnailURL else {
-            return nil
+        .task(id: recording.thumbnailURL) {
+            guard let url = recording.thumbnailURL else {
+                image = nil
+                return
+            }
+            let path = url.path
+            image = await Task.detached(priority: .utility) {
+                UIImage(contentsOfFile: path)
+            }.value
         }
-
-        return UIImage(contentsOfFile: thumbnailURL.path)
     }
 
     private var fallback: some View {

--- a/ASMR Walk/Features/Walk/WalkRecordingMetadataGenerator.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingMetadataGenerator.swift
@@ -28,7 +28,6 @@ nonisolated struct WalkRouteMetadataCoordinate: Equatable, Hashable, Sendable {
 }
 
 nonisolated struct WalkPlaceMetadata: Equatable, Sendable {
-    var areasOfInterest: [String] = []
     var name: String?
     var subLocality: String?
     var locality: String?
@@ -195,13 +194,7 @@ nonisolated enum WalkRecordingMetadataBuilder {
 
 nonisolated private extension WalkPlaceMetadata {
     var displayName: String? {
-        let candidates = areasOfInterest + [
-            name,
-            subLocality,
-            locality,
-            administrativeArea,
-            country
-        ].compactMap { $0 }
+        let candidates = [name, subLocality, locality, administrativeArea, country].compactMap { $0 }
 
         return candidates
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }


### PR DESCRIPTION
Addresses three issues found during the v1.1 QA review.

## Changes

**`RouteThumbnailView` — async disk read**
`UIImage(contentsOfFile:)` was called synchronously inside `body`, blocking the main thread on every List render pass. The image is now loaded on a detached utility task and stored in `@State`, keyed on `thumbnailURL` so it refreshes automatically when a new thumbnail is written.

**`HistoryView.refreshRouteThumbnails()` — parallel backfill**
Thumbnail generation for existing walks was sequential (one `await` per walk). Replaced the for-loop with `withTaskGroup` so walks that need a backfill are processed concurrently. For users upgrading from a pre-thumbnail build with many walks this is meaningfully faster.

**`WalkPlaceMetadata.areasOfInterest` — remove dead field**
`SystemWalkPlaceGeocoder` never populated this field (`MKMapItem` provides no array-of-areas equivalent to the old `CLPlacemark.areasOfInterest`). Removed the field and simplified the `displayName` candidate array.

## Test plan
- [ ] History list scrolls smoothly with a large library; thumbnails appear without jank
- [ ] On first launch after upgrade (no thumbnails), multiple thumbnails generate concurrently
- [ ] Metadata title/description generates correctly for GPS and video walks
- [ ] No compiler warnings or test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)