### PR TITLE
Prepare SwiftData schema for future iCloud sync

### DIFF
--- a/ASMR Walk/ASMR_WalkApp.swift
+++ b/ASMR Walk/ASMR_WalkApp.swift
@@ -11,16 +11,29 @@ import SwiftData
 @main
 struct ASMR_WalkApp: App {
     @UIApplicationDelegateAdaptor(AppOrientationDelegate.self) private var appOrientationDelegate
+    private let modelContainer: ModelContainer
 
     init() {
         UITestLaunchConfiguration.apply()
+        modelContainer = Self.makeModelContainer()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: [WalkRecording.self, LocationPoint.self])
+        .modelContainer(modelContainer)
+    }
+
+    private static func makeModelContainer() -> ModelContainer {
+        let schema = Schema([WalkRecording.self, LocationPoint.self])
+        let configuration = ModelConfiguration(schema: schema, cloudKitDatabase: .none)
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Unable to create ASMR Walk model container: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/ASMR Walk/Models/LocationPoint.swift
+++ b/ASMR Walk/Models/LocationPoint.swift
@@ -9,11 +9,11 @@ import SwiftData
 
 @Model
 final class LocationPoint {
-    var timestamp: Date
-    var latitude: Double
-    var longitude: Double
+    var timestamp: Date = Date.now
+    var latitude: Double = 0
+    var longitude: Double = 0
     var altitude: Double?
-    var horizontalAccuracy: Double
+    var horizontalAccuracy: Double = 0
     var speed: Double?
     var recording: WalkRecording?
 

--- a/ASMR Walk/Models/WalkRecording.swift
+++ b/ASMR Walk/Models/WalkRecording.swift
@@ -10,20 +10,28 @@ import SwiftData
 final class WalkRecording {
     static let shortRecordingThreshold: TimeInterval = 10
 
-    #Unique<WalkRecording>([\.id])
     #Index<WalkRecording>([\.createdAt])
 
-    var id: UUID
-    var title: String
-    var createdAt: Date
-    var duration: TimeInterval
-    var distanceMeters: Double
-    var mode: RecordingMode
+    var id: UUID = UUID()
+    var title: String = ""
+    var createdAt: Date = Date.now
+    var duration: TimeInterval = 0
+    var distanceMeters: Double = 0
+    var mode: RecordingMode = RecordingMode.walk
     var videoURL: URL?
     var videoAssetIdentifier: String?
 
-    @Relationship(deleteRule: .cascade, inverse: \LocationPoint.recording)
-    var points: [LocationPoint]
+    @Relationship(deleteRule: .cascade, originalName: "points", inverse: \LocationPoint.recording)
+    private var storedPoints: [LocationPoint]?
+
+    var points: [LocationPoint] {
+        get {
+            storedPoints ?? []
+        }
+        set {
+            storedPoints = newValue
+        }
+    }
 
     init(
         id: UUID = UUID(),
@@ -44,7 +52,7 @@ final class WalkRecording {
         self.mode = mode
         self.videoURL = videoURL
         self.videoAssetIdentifier = videoAssetIdentifier
-        self.points = points
+        self.storedPoints = points
     }
 
     var hasVideo: Bool {
@@ -60,6 +68,6 @@ final class WalkRecording {
     }
 
     func addPoint(_ point: LocationPoint) {
-        points.append(point)
+        storedPoints = points + [point]
     }
 }

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -708,6 +708,7 @@ struct WalkRecordingTests {
         #expect(recording.duration == 60)
         #expect(recording.distanceMeters == 180)
         #expect(recording.pointsInTimeOrder.map(\.timestamp) == secondCheckpoint.points.map(\.timestamp))
+        #expect(try ModelContext(container).fetchCount(FetchDescriptor<WalkRecording>()) == 1)
     }
 
     @Test("Repeated persistence checkpoints do not duplicate points")
@@ -729,6 +730,34 @@ struct WalkRecordingTests {
         let recording = try #require(try fetchRecording(id: recordingID, in: container))
         #expect(recording.points.count == 12)
         #expect(Set(recording.points.map(\.timestamp)).count == 12)
+        #expect(try ModelContext(container).fetchCount(FetchDescriptor<WalkRecording>()) == 1)
+    }
+
+    @Test("Schema hardening retains route data and local file references")
+    func schemaHardeningRetainsLocalRecordingData() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let videoURL = URL(filePath: "/tmp/local-video.mov")
+        let recording = WalkRecording(
+            title: "Beta Walk",
+            duration: 180,
+            distanceMeters: 540,
+            mode: .videoWalk,
+            videoURL: videoURL,
+            points: [
+                makePoint(timestamp: 100),
+                makePoint(timestamp: 120)
+            ]
+        )
+
+        context.insert(recording)
+        try context.save()
+
+        let fetched = try #require(try fetchRecording(id: recording.id, in: container))
+        #expect(fetched.title == "Beta Walk")
+        #expect(fetched.videoURL == videoURL)
+        #expect(fetched.points.count == 2)
+        #expect(fetched.pointsInTimeOrder.map(\.timestamp) == recording.pointsInTimeOrder.map(\.timestamp))
     }
 
     @Test("Final persistence save retains all points after partial checkpoints")

--- a/Journal.md
+++ b/Journal.md
@@ -259,6 +259,14 @@ One earlier design gave video walks a split ownership model: ASMR Walk kept the 
 
 That model taught the app to be precise about ownership. Legacy Photos-backed videos still remain in Photos when their ASMR Walk recording is deleted, and any user-saved Photos copy from the newer flow stays in Photos too.
 
+### Preparing the Filing Cabinet for iCloud
+
+The 1.0.1 release line made a quiet but important database change before ASMR Walk had public users. SwiftData's local filing cabinet was already working, but future iCloud sync has stricter house rules: no unique constraints and optional relationships only. Waiting until sync shipped would make public users cross that bridge later, with more real recordings at stake.
+
+So the app moved the route-point relationship behind an optional stored relationship while keeping the friendly `points` API the rest of the code already uses. It also stopped relying on SwiftData's unique constraint for `WalkRecording.id`; the persistence actor already behaves like the front-desk clerk who checks for an existing folder before creating a new one. CloudKit itself stays off in 1.0.1, but the schema is now shaped more like the sync-ready version that will follow.
+
+The lesson is release timing. A migration tested by beta users is a controlled rehearsal. The same migration sprung on a larger public audience is opening night with wet paint.
+
 ### The Video Came Back Home
 
 User testing flipped the video ownership model back to the simpler mental model: ASMR Walk records the video, ASMR Walk keeps the video, and Photos is an explicit export button instead of the default filing cabinet. New video walks now keep their `.mov` in app-managed storage and History playback uses that local file first. The detail screen offers **Save Video to Photos** when someone wants a copy in their library.


### PR DESCRIPTION
## Summary

- Removes the SwiftData unique constraint from `WalkRecording.id` so the model can later move to SwiftData + CloudKit.
- Adds defaults to non-optional persisted model properties and moves route points behind an optional stored relationship while preserving the existing `points` API.
- Creates an explicit app `ModelContainer` configuration with `cloudKitDatabase: .none` so 1.0.1 does not accidentally enable CloudKit sync.
- Adds tests for persistence duplicate handling, route retention, and local video URL retention.
- Updates `Journal.md` with the 1.0.1 schema-prep decision.

Closes #61.

## Beta Tester Notes

This 1.0.1 build includes a database schema preparation change for future iCloud sync, but iCloud sync is not enabled yet.

Please ask beta testers to verify:

- Existing saved walks still appear after updating.
- Existing routes still draw correctly in History and detail views.
- Existing video walks still play on the device where they were recorded.
- Deleting recordings still removes their routes and app-managed local video files as before.
- No new iCloud sync UI or behavior should appear in this build.

If a tester reports missing recordings, missing route lines, or videos that no longer play on the original recording device, treat that as release-blocking for 1.0.1.

## Validation

- Xcode live diagnostics: clean for changed Swift files.
- Xcode build: passed.
- Xcode MCP focused unit tests: 7 passed, 0 failed.
- Shell `xcodebuild test -project "ASMR Walk.xcodeproj" -scheme "ASMR Walk" -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` could not run in this environment because CoreSimulatorService is unavailable and Xcode reports no concrete simulator destinations.