### PR TITLE
Add Watch app target shell

### DIFF
--- a/ASMR Walk.xcodeproj/project.pbxproj
+++ b/ASMR Walk.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3A6821202FF06A2A0012C321 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3A68211F2FF06A2A0012C321 /* Launch Screen.storyboard */; };
+		3AA4BDA9304398A400E5D8A6 /* ASMRWalk Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3AC8940E300431E6003AC68B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AC8940D300431E6003AC68B /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
@@ -26,13 +27,51 @@
 			remoteGlobalIDString = 3A3E1F172FC3DE3500CFEE4A;
 			remoteInfo = "ASMR Walk";
 		};
+		3AA4BD96304398A400E5D8A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AA4BD88304398A400E5D8A6;
+			remoteInfo = "ASMRWalk Watch App";
+		};
+		3AA4BDA0304398A400E5D8A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AA4BD88304398A400E5D8A6;
+			remoteInfo = "ASMRWalk Watch App";
+		};
+		3AA4BDA7304398A400E5D8A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AA4BD88304398A400E5D8A6;
+			remoteInfo = "ASMRWalk Watch App";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3AA4BDAA304398A400E5D8A6 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				3AA4BDA9304398A400E5D8A6 /* ASMRWalk Watch App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		3A3E1F182FC3DE3500CFEE4A /* ASMR Walk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASMR Walk.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A3E1F252FC3DE3800CFEE4A /* ASMR WalkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR WalkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A3E1F2F2FC3DE3800CFEE4A /* ASMR WalkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR WalkUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A68211F2FF06A2A0012C321 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASMRWalk Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AA4BD95304398A400E5D8A6 /* ASMRWalk Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMRWalk Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AA4BD9F304398A400E5D8A6 /* ASMRWalk Watch AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMRWalk Watch AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AC8940D300431E6003AC68B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -65,6 +104,21 @@
 			path = "ASMR WalkUITests";
 			sourceTree = "<group>";
 		};
+		3AA4BD8A304398A400E5D8A6 /* ASMRWalk Watch App */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMRWalk Watch App";
+			sourceTree = "<group>";
+		};
+		3AA4BD98304398A400E5D8A6 /* ASMRWalk Watch AppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMRWalk Watch AppTests";
+			sourceTree = "<group>";
+		};
+		3AA4BDA2304398A400E5D8A6 /* ASMRWalk Watch AppUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMRWalk Watch AppUITests";
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +143,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3AA4BD86304398A400E5D8A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD92304398A400E5D8A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD9C304398A400E5D8A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -100,6 +175,9 @@
 				3A3E1F1A2FC3DE3500CFEE4A /* ASMR Walk */,
 				3A3E1F282FC3DE3800CFEE4A /* ASMR WalkTests */,
 				3A3E1F322FC3DE3800CFEE4A /* ASMR WalkUITests */,
+				3AA4BD8A304398A400E5D8A6 /* ASMRWalk Watch App */,
+				3AA4BD98304398A400E5D8A6 /* ASMRWalk Watch AppTests */,
+				3AA4BDA2304398A400E5D8A6 /* ASMRWalk Watch AppUITests */,
 				3A3E1F192FC3DE3500CFEE4A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -110,6 +188,9 @@
 				3A3E1F182FC3DE3500CFEE4A /* ASMR Walk.app */,
 				3A3E1F252FC3DE3800CFEE4A /* ASMR WalkTests.xctest */,
 				3A3E1F2F2FC3DE3800CFEE4A /* ASMR WalkUITests.xctest */,
+				3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */,
+				3AA4BD95304398A400E5D8A6 /* ASMRWalk Watch AppTests.xctest */,
+				3AA4BD9F304398A400E5D8A6 /* ASMRWalk Watch AppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -124,10 +205,12 @@
 				3A3E1F142FC3DE3500CFEE4A /* Sources */,
 				3A3E1F152FC3DE3500CFEE4A /* Frameworks */,
 				3A3E1F162FC3DE3500CFEE4A /* Resources */,
+				3AA4BDAA304398A400E5D8A6 /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3AA4BDA8304398A400E5D8A6 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				3A3E1F1A2FC3DE3500CFEE4A /* ASMR Walk */,
@@ -185,6 +268,74 @@
 			productReference = 3A3E1F2F2FC3DE3800CFEE4A /* ASMR WalkUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AA4BDB1304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch App" */;
+			buildPhases = (
+				3AA4BD85304398A400E5D8A6 /* Sources */,
+				3AA4BD86304398A400E5D8A6 /* Frameworks */,
+				3AA4BD87304398A400E5D8A6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3AA4BD8A304398A400E5D8A6 /* ASMRWalk Watch App */,
+			);
+			name = "ASMRWalk Watch App";
+			packageProductDependencies = (
+			);
+			productName = "ASMRWalk Watch App";
+			productReference = 3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3AA4BD94304398A400E5D8A6 /* ASMRWalk Watch AppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AA4BDB2304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch AppTests" */;
+			buildPhases = (
+				3AA4BD91304398A400E5D8A6 /* Sources */,
+				3AA4BD92304398A400E5D8A6 /* Frameworks */,
+				3AA4BD93304398A400E5D8A6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3AA4BD97304398A400E5D8A6 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3AA4BD98304398A400E5D8A6 /* ASMRWalk Watch AppTests */,
+			);
+			name = "ASMRWalk Watch AppTests";
+			packageProductDependencies = (
+			);
+			productName = "ASMRWalk Watch AppTests";
+			productReference = 3AA4BD95304398A400E5D8A6 /* ASMRWalk Watch AppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		3AA4BD9E304398A400E5D8A6 /* ASMRWalk Watch AppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AA4BDB3304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch AppUITests" */;
+			buildPhases = (
+				3AA4BD9B304398A400E5D8A6 /* Sources */,
+				3AA4BD9C304398A400E5D8A6 /* Frameworks */,
+				3AA4BD9D304398A400E5D8A6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3AA4BDA1304398A400E5D8A6 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3AA4BDA2304398A400E5D8A6 /* ASMRWalk Watch AppUITests */,
+			);
+			name = "ASMRWalk Watch AppUITests";
+			packageProductDependencies = (
+			);
+			productName = "ASMRWalk Watch AppUITests";
+			productReference = 3AA4BD9F304398A400E5D8A6 /* ASMRWalk Watch AppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -192,7 +343,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2650;
+				LastSwiftUpdateCheck = 2660;
 				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					3A3E1F172FC3DE3500CFEE4A = {
@@ -205,6 +356,17 @@
 					3A3E1F2E2FC3DE3800CFEE4A = {
 						CreatedOnToolsVersion = 26.5;
 						TestTargetID = 3A3E1F172FC3DE3500CFEE4A;
+					};
+					3AA4BD88304398A400E5D8A6 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+					3AA4BD94304398A400E5D8A6 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = 3AA4BD88304398A400E5D8A6;
+					};
+					3AA4BD9E304398A400E5D8A6 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = 3AA4BD88304398A400E5D8A6;
 					};
 				};
 			};
@@ -225,6 +387,9 @@
 				3A3E1F172FC3DE3500CFEE4A /* ASMR Walk */,
 				3A3E1F242FC3DE3800CFEE4A /* ASMR WalkTests */,
 				3A3E1F2E2FC3DE3800CFEE4A /* ASMR WalkUITests */,
+				3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */,
+				3AA4BD94304398A400E5D8A6 /* ASMRWalk Watch AppTests */,
+				3AA4BD9E304398A400E5D8A6 /* ASMRWalk Watch AppUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -247,6 +412,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3A3E1F2D2FC3DE3800CFEE4A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD87304398A400E5D8A6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD93304398A400E5D8A6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD9D304398A400E5D8A6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -277,6 +463,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3AA4BD85304398A400E5D8A6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD91304398A400E5D8A6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA4BD9B304398A400E5D8A6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -289,6 +496,21 @@
 			isa = PBXTargetDependency;
 			target = 3A3E1F172FC3DE3500CFEE4A /* ASMR Walk */;
 			targetProxy = 3A3E1F302FC3DE3800CFEE4A /* PBXContainerItemProxy */;
+		};
+		3AA4BD97304398A400E5D8A6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */;
+			targetProxy = 3AA4BD96304398A400E5D8A6 /* PBXContainerItemProxy */;
+		};
+		3AA4BDA1304398A400E5D8A6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */;
+			targetProxy = 3AA4BDA0304398A400E5D8A6 /* PBXContainerItemProxy */;
+		};
+		3AA4BDA8304398A400E5D8A6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */;
+			targetProxy = 3AA4BDA7304398A400E5D8A6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -614,6 +836,162 @@
 			};
 			name = Release;
 		};
+		3AA4BDAB304398A400E5D8A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = ASMRWalk;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.bald-traveler.ASMR-Walk";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Debug;
+		};
+		3AA4BDAC304398A400E5D8A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = ASMRWalk;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.bald-traveler.ASMR-Walk";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Release;
+		};
+		3AA4BDAD304398A400E5D8A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalk-Watch-AppTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ASMRWalk Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ASMRWalk Watch App";
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Debug;
+		};
+		3AA4BDAE304398A400E5D8A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalk-Watch-AppTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ASMRWalk Watch App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ASMRWalk Watch App";
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Release;
+		};
+		3AA4BDAF304398A400E5D8A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalk-Watch-AppUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_TARGET_NAME = "ASMRWalk Watch App";
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Debug;
+		};
+		3AA4BDB0304398A400E5D8A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalk-Watch-AppUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_TARGET_NAME = "ASMRWalk Watch App";
+				WATCHOS_DEPLOYMENT_TARGET = 26.5;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -649,6 +1027,33 @@
 			buildConfigurations = (
 				3A3E1F402FC3DE3800CFEE4A /* Debug */,
 				3A3E1F412FC3DE3800CFEE4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AA4BDB1304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AA4BDAB304398A400E5D8A6 /* Debug */,
+				3AA4BDAC304398A400E5D8A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AA4BDB2304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch AppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AA4BDAD304398A400E5D8A6 /* Debug */,
+				3AA4BDAE304398A400E5D8A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AA4BDB3304398A400E5D8A6 /* Build configuration list for PBXNativeTarget "ASMRWalk Watch AppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AA4BDAF304398A400E5D8A6 /* Debug */,
+				3AA4BDB0304398A400E5D8A6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ASMR Walk.xcodeproj/xcuserdata/heathdj.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ASMR Walk.xcodeproj/xcuserdata/heathdj.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,6 +9,11 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
+		<key>ASMRWalk Watch App.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/ASMRWalk Watch App/ASMRWalkApp.swift
+++ b/ASMRWalk Watch App/ASMRWalkApp.swift
@@ -1,0 +1,17 @@
+//
+//  ASMRWalkApp.swift
+//  ASMRWalk Watch App
+//
+//  Created by David Heath on 8/29/26.
+//
+
+import SwiftUI
+
+@main
+struct ASMRWalk_Watch_AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ASMRWalk Watch App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ASMRWalk Watch App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMRWalk Watch App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ASMRWalk Watch App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMRWalk Watch App/Assets.xcassets/Contents.json
+++ b/ASMRWalk Watch App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMRWalk Watch App/ContentView.swift
+++ b/ASMRWalk Watch App/ContentView.swift
@@ -1,0 +1,32 @@
+//
+//  ContentView.swift
+//  ASMRWalk Watch App
+//
+//  Created by David Heath on 8/29/26.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "figure.walk.circle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.green)
+
+            Text("ASMR Walk")
+                .font(.headline)
+
+            Text("Watch recording setup")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ASMRWalk Watch AppTests/ASMRWalk_Watch_AppTests.swift
+++ b/ASMRWalk Watch AppTests/ASMRWalk_Watch_AppTests.swift
@@ -1,0 +1,19 @@
+//
+//  ASMRWalk_Watch_AppTests.swift
+//  ASMRWalk Watch AppTests
+//
+//  Created by David Heath on 8/29/26.
+//
+
+import Testing
+@testable import ASMRWalk_Watch_App
+
+struct ASMRWalk_Watch_AppTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // Swift Testing Documentation
+        // https://developer.apple.com/documentation/testing
+    }
+
+}

--- a/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
+++ b/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
@@ -1,0 +1,43 @@
+//
+//  ASMRWalk_Watch_AppUITests.swift
+//  ASMRWalk Watch AppUITests
+//
+//  Created by David Heath on 8/29/26.
+//
+
+import XCTest
+
+final class ASMRWalk_Watch_AppUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITestsLaunchTests.swift
+++ b/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITestsLaunchTests.swift
@@ -1,0 +1,35 @@
+//
+//  ASMRWalk_Watch_AppUITestsLaunchTests.swift
+//  ASMRWalk Watch AppUITests
+//
+//  Created by David Heath on 8/29/26.
+//
+
+import XCTest
+
+final class ASMRWalk_Watch_AppUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Journal.md
+++ b/Journal.md
@@ -369,6 +369,12 @@ The thumbnail generator follows the same rule as place metadata: save the walk f
 
 Cleanup needed its own little checklist. Video files and thumbnails are both app-managed local files, so deletion now asks `WalkRecordingLocalFiles` for everything that belongs to the recording and removes those files after SwiftData deletes the row. The route stays local-first, the thumbnail stays lightweight, and no one has to wonder why a deleted walk left a tiny souvenir behind.
 
+### The Watch App Gets a Front Door
+
+Issue 65 starts the Apple Watch chapter without trying to solve the whole hike in one stride. The owner-driven Xcode work added the Watch target, because target creation is one of those places where the project file is more like wet cement than a normal source file. Let Xcode shape it; then inspect what it made.
+
+The first pass also revealed a classic template-name hiccup: two Watch app folders appeared, but only `ASMRWalk Watch App` was actually wired into the project. The unused duplicate was removed before it could become fossilized confusion. The Watch app now opens to a tiny ASMR Walk-branded shell, which is exactly enough for target setup: a front door, not the full recording dashboard. GPS recording, Watch UI polish, sync, and release validation each have their own issue because a watchOS feature is easier to build when every part gets its own trail marker.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary

- Add the `ASMRWalk Watch App` watchOS target, test target, UI test target, assets, and generated project wiring from Xcode.
- Replace the default Watch placeholder with a minimal ASMR Walk-branded setup shell.
- Remove the stale duplicate Watchapp template files/scheme entry and document the target setup in `Journal.md`.

## Owner Actions Completed

- Basic Watch app target was added in Xcode.
- Watch app built and ran on simulator.
- Bundle identifier observed for the Watch app target: `com.bald-traveler.ASMR-Walk.watchkitapp`.
- Companion app identifier points at the iPhone app bundle: `com.bald-traveler.ASMR-Walk`.

## Deferred To Later Issues

- Watch CloudKit capability setup is deferred to #69, where sync behavior will be implemented and validated.
- Watch GPS recording remains in #67.
- Watch recording UI remains in #68.
- Release/device validation remains in #71.

## Validation

- Xcode MCP `BuildProject`: passed.
- Xcode live diagnostics for `ASMRWalk Watch App/ContentView.swift`: no issues.
- `git diff --check --cached`: passed before commit.

Closes #65.
