### PR TITLE
Add Watch recording metadata fields

### DIFF
--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -186,6 +186,12 @@ private extension WalkRecording {
             duration: duration,
             distanceMeters: distanceMeters,
             mode: mode,
+            recordingSource: source,
+            captureDeviceName: captureDeviceName,
+            routeStartedAt: routeStartedAt,
+            routeEndedAt: routeEndedAt,
+            externalVideoReference: externalVideoReference,
+            externalVideoStartedAt: externalVideoStartedAt,
             videoURL: videoURL,
             videoAssetIdentifier: videoAssetIdentifier,
             points: pointsInTimeOrder.map { point in

--- a/ASMR Walk/Features/History/WalkRouteExport.swift
+++ b/ASMR Walk/Features/History/WalkRouteExport.swift
@@ -24,6 +24,12 @@ struct WalkRouteExport {
     let duration: TimeInterval
     let mode: RecordingMode
     let hasVideo: Bool
+    let recordingSource: WalkRecordingSource
+    let captureDeviceName: String?
+    let routeStartedAt: Date
+    let routeEndedAt: Date
+    let externalVideoReference: String?
+    let externalVideoStartedAt: Date?
     let points: [Point]
 
     @MainActor
@@ -35,6 +41,12 @@ struct WalkRouteExport {
         duration = recording.duration
         mode = recording.mode
         hasVideo = recording.hasVideo
+        recordingSource = recording.source
+        captureDeviceName = recording.captureDeviceName
+        routeStartedAt = recording.routeTimingStart
+        routeEndedAt = recording.routeTimingEnd
+        externalVideoReference = recording.externalVideoReference
+        externalVideoStartedAt = recording.externalVideoStartedAt
         points = recording.pointsInTimeOrder.map {
             Point(
                 timestamp: $0.timestamp,
@@ -104,8 +116,27 @@ struct WalkRouteExport {
 
     private var trackExtensionsXML: String {
         """
-        <extensions><asmrwalk:recordingID>\(recordingID.uuidString.xmlEscaped)</asmrwalk:recordingID><asmrwalk:durationSeconds>\(duration.gpxNumberText)</asmrwalk:durationSeconds><asmrwalk:recordingMode>\(mode.rawValue.xmlEscaped)</asmrwalk:recordingMode><asmrwalk:hasVideo>\(hasVideo ? "true" : "false")</asmrwalk:hasVideo>\(descriptionExtensionXML)</extensions>
+        <extensions><asmrwalk:recordingID>\(recordingID.uuidString.xmlEscaped)</asmrwalk:recordingID><asmrwalk:durationSeconds>\(duration.gpxNumberText)</asmrwalk:durationSeconds><asmrwalk:recordingMode>\(mode.rawValue.xmlEscaped)</asmrwalk:recordingMode><asmrwalk:recordingSource>\(recordingSource.rawValue.xmlEscaped)</asmrwalk:recordingSource>\(captureDeviceXML)<asmrwalk:routeStartedAt>\(routeStartedAt.ISO8601Format())</asmrwalk:routeStartedAt><asmrwalk:routeEndedAt>\(routeEndedAt.ISO8601Format())</asmrwalk:routeEndedAt><asmrwalk:hasVideo>\(hasVideo ? "true" : "false")</asmrwalk:hasVideo>\(descriptionExtensionXML)\(externalVideoXML)</extensions>
         """
+    }
+
+    private var captureDeviceXML: String {
+        guard let captureDeviceName, captureDeviceName.isEmpty == false else {
+            return ""
+        }
+
+        return "<asmrwalk:captureDeviceName>\(captureDeviceName.xmlEscaped)</asmrwalk:captureDeviceName>"
+    }
+
+    private var externalVideoXML: String {
+        var values = ""
+        if let externalVideoReference, externalVideoReference.isEmpty == false {
+            values += "<asmrwalk:externalVideoReference>\(externalVideoReference.xmlEscaped)</asmrwalk:externalVideoReference>"
+        }
+        if let externalVideoStartedAt {
+            values += "<asmrwalk:externalVideoStartedAt>\(externalVideoStartedAt.ISO8601Format())</asmrwalk:externalVideoStartedAt>"
+        }
+        return values
     }
 
     private var descriptionXML: String {

--- a/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingPersistence.swift
@@ -17,6 +17,12 @@ actor WalkRecordingPersistence {
         recording.duration = snapshot.duration
         recording.distanceMeters = snapshot.distanceMeters
         recording.mode = snapshot.mode
+        recording.recordingSource = snapshot.recordingSource.rawValue
+        recording.captureDeviceName = snapshot.captureDeviceName
+        recording.routeStartedAt = snapshot.routeStartedAt
+        recording.routeEndedAt = snapshot.routeEndedAt
+        recording.externalVideoReference = snapshot.externalVideoReference
+        recording.externalVideoStartedAt = snapshot.externalVideoStartedAt
         recording.videoURL = snapshot.videoURL
         recording.videoAssetIdentifier = snapshot.videoAssetIdentifier
 
@@ -82,6 +88,12 @@ actor WalkRecordingPersistence {
             duration: snapshot.duration,
             distanceMeters: snapshot.distanceMeters,
             mode: snapshot.mode,
+            recordingSource: snapshot.recordingSource,
+            captureDeviceName: snapshot.captureDeviceName,
+            routeStartedAt: snapshot.routeStartedAt,
+            routeEndedAt: snapshot.routeEndedAt,
+            externalVideoReference: snapshot.externalVideoReference,
+            externalVideoStartedAt: snapshot.externalVideoStartedAt,
             videoURL: snapshot.videoURL,
             videoAssetIdentifier: snapshot.videoAssetIdentifier,
             points: snapshot.points.map { makeLocationPoint(from: $0) }

--- a/ASMR Walk/Features/Walk/WalkRecordingSession.swift
+++ b/ASMR Walk/Features/Walk/WalkRecordingSession.swift
@@ -28,6 +28,12 @@ struct WalkRecordingSnapshot: Identifiable, Sendable {
     var duration: TimeInterval
     var distanceMeters: Double
     var mode: RecordingMode
+    var recordingSource: WalkRecordingSource
+    var captureDeviceName: String?
+    var routeStartedAt: Date?
+    var routeEndedAt: Date?
+    var externalVideoReference: String?
+    var externalVideoStartedAt: Date?
     var videoURL: URL?
     var videoAssetIdentifier: String?
     var points: [LocationPointSnapshot]
@@ -58,6 +64,12 @@ final class WalkRecordingSession {
             duration: 0,
             distanceMeters: 0,
             mode: mode,
+            recordingSource: .iPhone,
+            captureDeviceName: nil,
+            routeStartedAt: startedAt,
+            routeEndedAt: nil,
+            externalVideoReference: nil,
+            externalVideoStartedAt: nil,
             points: []
         )
     }
@@ -94,6 +106,7 @@ final class WalkRecordingSession {
 
     func updateDuration(at date: Date = .now) {
         snapshot.duration = max(0, date.timeIntervalSince(snapshot.createdAt))
+        snapshot.routeEndedAt = date
     }
 
     func attachVideo(at url: URL) {

--- a/ASMR Walk/Models/WalkRecording+Presentation.swift
+++ b/ASMR Walk/Models/WalkRecording+Presentation.swift
@@ -50,6 +50,43 @@ extension WalkRecording {
         WalkRecordingVideoStoragePolicy(rawValue: videoStoragePolicy) ?? .localOnly
     }
 
+    var source: WalkRecordingSource {
+        WalkRecordingSource(rawValue: recordingSource) ?? .iPhone
+    }
+
+    var sourceTitle: String {
+        source.title
+    }
+
+    var isWatchRecording: Bool {
+        source == .appleWatch
+    }
+
+    var routeTimingStart: Date {
+        routeStartedAt ?? createdAt
+    }
+
+    var routeTimingEnd: Date {
+        routeEndedAt ?? routeTimingStart.addingTimeInterval(duration)
+    }
+
+    var externalCameraTimingMessage: String {
+        guard let externalVideoStartedAt else {
+            return "No external camera timing has been attached."
+        }
+
+        let offset = externalVideoStartedAt.timeIntervalSince(routeTimingStart)
+        if abs(offset) < 0.5 {
+            return "External camera timing starts with the recorded route."
+        }
+
+        if offset > 0 {
+            return "External camera timing starts \(offset.timerText) after the route."
+        }
+
+        return "External camera timing starts \(abs(offset).timerText) before the route."
+    }
+
     var titleConflictTimestamp: Date? {
         guard isTitleUserEdited else {
             return nil

--- a/ASMR Walk/Models/WalkRecording.swift
+++ b/ASMR Walk/Models/WalkRecording.swift
@@ -25,6 +25,12 @@ final class WalkRecording {
     var isDescriptionUserEdited: Bool = false
     var titleEditedAt: Date?
     var descriptionEditedAt: Date?
+    var recordingSource: String = WalkRecordingSource.iPhone.rawValue
+    var captureDeviceName: String?
+    var routeStartedAt: Date?
+    var routeEndedAt: Date?
+    var externalVideoReference: String?
+    var externalVideoStartedAt: Date?
     var videoURL: URL?
     var videoAssetIdentifier: String?
     var videoStoragePolicy: String = WalkRecordingVideoStoragePolicy.localOnly.rawValue
@@ -57,6 +63,12 @@ final class WalkRecording {
         isDescriptionUserEdited: Bool = false,
         titleEditedAt: Date? = nil,
         descriptionEditedAt: Date? = nil,
+        recordingSource: WalkRecordingSource = .iPhone,
+        captureDeviceName: String? = nil,
+        routeStartedAt: Date? = nil,
+        routeEndedAt: Date? = nil,
+        externalVideoReference: String? = nil,
+        externalVideoStartedAt: Date? = nil,
         videoURL: URL? = nil,
         videoAssetIdentifier: String? = nil,
         videoStoragePolicy: WalkRecordingVideoStoragePolicy = .localOnly,
@@ -77,6 +89,12 @@ final class WalkRecording {
         self.isDescriptionUserEdited = isDescriptionUserEdited
         self.titleEditedAt = titleEditedAt
         self.descriptionEditedAt = descriptionEditedAt
+        self.recordingSource = recordingSource.rawValue
+        self.captureDeviceName = captureDeviceName
+        self.routeStartedAt = routeStartedAt
+        self.routeEndedAt = routeEndedAt
+        self.externalVideoReference = externalVideoReference
+        self.externalVideoStartedAt = externalVideoStartedAt
         self.videoURL = videoURL
         self.videoAssetIdentifier = videoAssetIdentifier
         self.videoStoragePolicy = videoStoragePolicy.rawValue
@@ -99,6 +117,20 @@ final class WalkRecording {
 
     func addPoint(_ point: LocationPoint) {
         storedPoints = points + [point]
+    }
+}
+
+enum WalkRecordingSource: String, Codable, CaseIterable, Sendable {
+    case iPhone
+    case appleWatch
+
+    var title: String {
+        switch self {
+        case .iPhone:
+            "iPhone"
+        case .appleWatch:
+            "Apple Watch"
+        }
     }
 }
 

--- a/ASMR WalkTests/ASMR_WalkTests.swift
+++ b/ASMR WalkTests/ASMR_WalkTests.swift
@@ -701,6 +701,13 @@ struct WalkRecordingTests {
         #expect(recording.metadataGeneratedAt == nil)
         #expect(recording.isTitleUserEdited == false)
         #expect(recording.isDescriptionUserEdited == false)
+        #expect(recording.source == .iPhone)
+        #expect(recording.sourceTitle == "iPhone")
+        #expect(recording.captureDeviceName == nil)
+        #expect(recording.routeTimingStart == createdAt)
+        #expect(recording.routeTimingEnd == createdAt.addingTimeInterval(300))
+        #expect(recording.externalVideoReference == nil)
+        #expect(recording.externalVideoStartedAt == nil)
         #expect(recording.thumbnailURL == nil)
         #expect(recording.thumbnailStyleVersion == 0)
         #expect(recording.points.isEmpty)
@@ -758,6 +765,47 @@ struct WalkRecordingTests {
         #expect(WalkRecording.shortRecordingThreshold == 10)
         #expect(shortWalk.isShortRecording)
         #expect(tenSecondWalk.isShortRecording == false)
+    }
+
+    @Test("Watch recording metadata has safe presentation defaults")
+    func watchRecordingMetadataPresentation() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let endedAt = Date(timeIntervalSince1970: 1_300)
+        let recording = WalkRecording(
+            title: "Watch Walk",
+            createdAt: startedAt,
+            duration: 300,
+            mode: .walk,
+            recordingSource: .appleWatch,
+            captureDeviceName: "David's Apple Watch",
+            routeStartedAt: startedAt,
+            routeEndedAt: endedAt
+        )
+
+        #expect(recording.source == .appleWatch)
+        #expect(recording.sourceTitle == "Apple Watch")
+        #expect(recording.isWatchRecording)
+        #expect(recording.routeTimingStart == startedAt)
+        #expect(recording.routeTimingEnd == endedAt)
+        #expect(recording.externalCameraTimingMessage == "No external camera timing has been attached.")
+    }
+
+    @Test("External camera timing describes its route offset")
+    func externalCameraTimingPresentation() {
+        let routeStart = Date(timeIntervalSince1970: 1_000)
+        let recording = WalkRecording(
+            title: "External Camera Walk",
+            createdAt: routeStart,
+            duration: 300,
+            mode: .walk,
+            recordingSource: .appleWatch,
+            routeStartedAt: routeStart,
+            externalVideoReference: "A-cam clip 012",
+            externalVideoStartedAt: routeStart.addingTimeInterval(-5)
+        )
+
+        #expect(recording.externalVideoReference == "A-cam clip 012")
+        #expect(recording.externalCameraTimingMessage == "External camera timing starts 0:05 before the route.")
     }
 
     @Test("Video playback route progress follows recorded point timing")
@@ -969,6 +1017,9 @@ struct WalkRecordingTests {
         #expect(recording.points.count == 15)
         #expect(recording.duration == 60)
         #expect(recording.distanceMeters == 180)
+        #expect(recording.recordingSource == WalkRecordingSource.iPhone.rawValue)
+        #expect(recording.routeStartedAt == firstCheckpoint.routeStartedAt)
+        #expect(recording.routeEndedAt == secondCheckpoint.routeEndedAt)
         #expect(recording.pointsInTimeOrder.map(\.timestamp) == secondCheckpoint.points.map(\.timestamp))
         #expect(try ModelContext(container).fetchCount(FetchDescriptor<WalkRecording>()) == 1)
     }
@@ -1111,6 +1162,39 @@ struct WalkRecordingTests {
         #expect(recording.duration == 75)
         #expect(recording.points.count == 8)
         #expect(recording.pointsInTimeOrder.map(\.timestamp) == metadataOnlyCheckpoint.points.map(\.timestamp))
+    }
+
+    @Test("Persistence stores Watch source and external camera timing metadata")
+    func persistenceStoresWatchSourceAndExternalCameraTiming() async throws {
+        let recordingID = try #require(UUID(uuidString: "F30E2C38-8714-4FA5-B30D-817AE52A0E77"))
+        let routeStartedAt = Date(timeIntervalSince1970: 2_000)
+        let routeEndedAt = Date(timeIntervalSince1970: 2_420)
+        let externalVideoStartedAt = Date(timeIntervalSince1970: 1_995)
+        let container = try makeContainer()
+        let persistence = WalkRecordingPersistence(modelContainer: container)
+        let snapshot = makeSnapshot(
+            id: recordingID,
+            createdAt: routeStartedAt,
+            duration: 420,
+            distanceMeters: 1_200,
+            pointCount: 12,
+            recordingSource: .appleWatch,
+            captureDeviceName: "Apple Watch Ultra",
+            routeStartedAt: routeStartedAt,
+            routeEndedAt: routeEndedAt,
+            externalVideoReference: "Camera A clip 001",
+            externalVideoStartedAt: externalVideoStartedAt
+        )
+
+        try await persistence.save(snapshot)
+
+        let recording = try #require(try fetchRecording(id: recordingID, in: container))
+        #expect(recording.source == .appleWatch)
+        #expect(recording.captureDeviceName == "Apple Watch Ultra")
+        #expect(recording.routeStartedAt == routeStartedAt)
+        #expect(recording.routeEndedAt == routeEndedAt)
+        #expect(recording.externalVideoReference == "Camera A clip 001")
+        #expect(recording.externalVideoStartedAt == externalVideoStartedAt)
     }
 
     @Test("Persistence applies generated metadata without overwriting user edits")
@@ -1267,6 +1351,9 @@ struct WalkRecordingTests {
         #expect(gpxText.contains("<asmrwalk:recordingID>\(recordingID.uuidString)</asmrwalk:recordingID>"))
         #expect(gpxText.contains("<asmrwalk:durationSeconds>142.75</asmrwalk:durationSeconds>"))
         #expect(gpxText.contains("<asmrwalk:recordingMode>videoWalk</asmrwalk:recordingMode>"))
+        #expect(gpxText.contains("<asmrwalk:recordingSource>iPhone</asmrwalk:recordingSource>"))
+        #expect(gpxText.contains("<asmrwalk:routeStartedAt>1970-01-01T00:05:00Z</asmrwalk:routeStartedAt>"))
+        #expect(gpxText.contains("<asmrwalk:routeEndedAt>1970-01-01T00:07:22Z</asmrwalk:routeEndedAt>"))
         #expect(gpxText.contains("<asmrwalk:hasVideo>true</asmrwalk:hasVideo>"))
         #expect(gpxText.contains("<asmrwalk:horizontalAccuracyMeters>4.25</asmrwalk:horizontalAccuracyMeters>"))
         #expect(gpxText.contains("<asmrwalk:horizontalAccuracyMeters>8</asmrwalk:horizontalAccuracyMeters>"))
@@ -1274,6 +1361,37 @@ struct WalkRecordingTests {
         #expect(gpxText.components(separatedBy: "<asmrwalk:speedMetersPerSecond>").count - 1 == 1)
         #expect(gpxText.contains("video.mov") == false)
         #expect(gpxText.contains("/private/var/mobile") == false)
+    }
+
+    @Test("GPX export includes Watch and external camera timing metadata")
+    func gpxExportIncludesWatchAndExternalCameraMetadata() {
+        let routeStartedAt = Date(timeIntervalSince1970: 1_000)
+        let routeEndedAt = Date(timeIntervalSince1970: 1_240)
+        let externalVideoStartedAt = Date(timeIntervalSince1970: 995)
+        let recording = WalkRecording(
+            title: "Watch Export",
+            createdAt: routeStartedAt,
+            duration: 240,
+            mode: .walk,
+            recordingSource: .appleWatch,
+            captureDeviceName: "David's Apple Watch & Camera",
+            routeStartedAt: routeStartedAt,
+            routeEndedAt: routeEndedAt,
+            externalVideoReference: "A-cam <clip 12>",
+            externalVideoStartedAt: externalVideoStartedAt,
+            points: [
+                makePoint(timestamp: 1_000)
+            ]
+        )
+
+        let gpxText = WalkRouteExport(recording: recording).gpxText
+
+        #expect(gpxText.contains("<asmrwalk:recordingSource>appleWatch</asmrwalk:recordingSource>"))
+        #expect(gpxText.contains("<asmrwalk:captureDeviceName>David&apos;s Apple Watch &amp; Camera</asmrwalk:captureDeviceName>"))
+        #expect(gpxText.contains("<asmrwalk:routeStartedAt>1970-01-01T00:16:40Z</asmrwalk:routeStartedAt>"))
+        #expect(gpxText.contains("<asmrwalk:routeEndedAt>1970-01-01T00:20:40Z</asmrwalk:routeEndedAt>"))
+        #expect(gpxText.contains("<asmrwalk:externalVideoReference>A-cam &lt;clip 12&gt;</asmrwalk:externalVideoReference>"))
+        #expect(gpxText.contains("<asmrwalk:externalVideoStartedAt>1970-01-01T00:16:35Z</asmrwalk:externalVideoStartedAt>"))
     }
 
     @Test("GPX export includes recording descriptions")
@@ -1341,7 +1459,13 @@ struct WalkRecordingTests {
         distanceMeters: Double,
         pointCount: Int,
         latitude: Double = 33.4484,
-        longitude: Double = -112.0740
+        longitude: Double = -112.0740,
+        recordingSource: WalkRecordingSource = .iPhone,
+        captureDeviceName: String? = nil,
+        routeStartedAt: Date? = nil,
+        routeEndedAt: Date? = nil,
+        externalVideoReference: String? = nil,
+        externalVideoStartedAt: Date? = nil
     ) -> WalkRecordingSnapshot {
         WalkRecordingSnapshot(
             id: id,
@@ -1350,6 +1474,12 @@ struct WalkRecordingTests {
             duration: duration,
             distanceMeters: distanceMeters,
             mode: .walk,
+            recordingSource: recordingSource,
+            captureDeviceName: captureDeviceName,
+            routeStartedAt: routeStartedAt ?? createdAt,
+            routeEndedAt: routeEndedAt ?? createdAt.addingTimeInterval(duration),
+            externalVideoReference: externalVideoReference,
+            externalVideoStartedAt: externalVideoStartedAt,
             points: (0..<pointCount).map { index in
                 LocationPointSnapshot(
                     timestamp: createdAt.addingTimeInterval(TimeInterval(index)),

--- a/ASMRWalk Watch App/ContentView.swift
+++ b/ASMRWalk Watch App/ContentView.swift
@@ -26,7 +26,3 @@ struct ContentView: View {
         .accessibilityElement(children: .combine)
     }
 }
-
-#Preview {
-    ContentView()
-}

--- a/Journal.md
+++ b/Journal.md
@@ -375,6 +375,12 @@ Issue 65 starts the Apple Watch chapter without trying to solve the whole hike i
 
 The first pass also revealed a classic template-name hiccup: two Watch app folders appeared, but only `ASMRWalk Watch App` was actually wired into the project. The unused duplicate was removed before it could become fossilized confusion. The Watch app now opens to a tiny ASMR Walk-branded shell, which is exactly enough for target setup: a front door, not the full recording dashboard. GPS recording, Watch UI polish, sync, and release validation each have their own issue because a watchOS feature is easier to build when every part gets its own trail marker.
 
+### Metadata Is the Sync Handshake
+
+Issue 66 gives future Watch walks and external-camera shoots a passport before they start traveling through the app. The recording model now stores where a route came from, what device captured it, and the timing anchors that can line a route up with footage recorded somewhere else.
+
+The important constraint is CloudKit manners: every new field is optional or safely defaulted. Existing iPhone recordings keep behaving like iPhone recordings, and old synced rows do not need a dramatic migration ceremony. GPX export also carries the new source and timing fields, because the Mac importer and FCP plugin should not have to guess whether a route came from an iPhone, an Apple Watch, or a walk paired with an external camera clip.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary

- Add additive SwiftData metadata for recording source, capture device name, route timing anchors, and external-camera timing references.
- Carry the new metadata through `WalkRecordingSnapshot`, persistence checkpoints, route thumbnail snapshots, presentation helpers, and GPX export extensions.
- Default existing/iPhone recordings to the current iPhone behavior while leaving Watch and external-camera values optional until #67/#68/#69 implement recording and sync flows.
- Remove the Watch shell `#Preview` block after shell `xcodebuild` exposed a sandboxed preview-macro failure during app-scheme validation.
- Document the metadata decision in `Journal.md`.

## Compatibility

All new SwiftData fields are optional or safely defaulted for CloudKit compatibility and existing-user upgrade behavior:

- `recordingSource` defaults to `iPhone`.
- `captureDeviceName`, `routeStartedAt`, `routeEndedAt`, `externalVideoReference`, and `externalVideoStartedAt` are optional.
- Presentation/export helpers fall back to `createdAt + duration` when route timing anchors are absent.

## Validation

- Xcode MCP `BuildProject`: passed.
- Xcode live diagnostics: clean for edited app Swift files.
- `git diff --check`: passed.

## Validation Caveat

The shell `xcodebuild` app-scheme test/build attempts were blocked by the local sandbox/CoreSimulator/asset-catalog environment, not by Swift compile diagnostics:

- `xcodebuild test ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` could not find that simulator from the shell.
- `xcodebuild build-for-testing ... -derivedDataPath /tmp/ASMRWalkDerivedData` progressed into build work but failed in asset catalog/CoreSimulator tooling around `AppIcon`.

Closes #66.
