### PR TITLE
Build Watch recording dashboard

### DIFF
--- a/ASMRWalk Watch App/ContentView.swift
+++ b/ASMRWalk Watch App/ContentView.swift
@@ -13,36 +13,17 @@ struct ContentView: View {
     @State private var recorder = WatchRecorder()
 
     var body: some View {
-        VStack(spacing: 10) {
-            statusHeader
-            metrics
-
-            if recorder.isRecording {
-                Button("Stop", systemImage: "stop.fill") {
-                    Task {
-                        await recorder.stopAndSave()
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
-
-                Button("Discard", role: .destructive) {
-                    Task {
-                        await recorder.discard()
-                    }
-                }
-                .font(.footnote)
-            } else {
-                Button("Start Walk", systemImage: "figure.walk") {
-                    Task {
-                        await recorder.start(in: modelContext)
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(recorder.canStartRecording == false)
+        ScrollView {
+            VStack(spacing: 12) {
+                statusHeader
+                metricsGrid
+                gpsStatus
+                recordingControls
             }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
         }
-        .padding()
+        .accessibilityElement(children: .contain)
         .task {
             recorder.refreshAuthorizationStatus()
         }
@@ -50,40 +31,196 @@ struct ContentView: View {
 
     private var statusHeader: some View {
         VStack(spacing: 4) {
-            Image(systemName: recorder.isRecording ? "figure.walk.circle.fill" : "figure.walk.circle")
-                .font(.system(size: 34))
-                .foregroundStyle(recorder.isRecording ? .green : .secondary)
+            Image(systemName: statusSymbol)
+                .font(.system(size: 40))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(statusColor)
 
             Text(recorder.statusTitle)
-                .font(.headline)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.center)
 
             Text(recorder.statusDetail)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
-                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .accessibilityElement(children: .combine)
     }
 
-    private var metrics: some View {
-        HStack(spacing: 12) {
-            metric(recorder.currentDuration.timerText, label: "Time")
-            metric(recorder.currentDistanceMeters.distanceText, label: "Distance")
-            metric("\(recorder.pointCount)", label: "Points")
+    private var metricsGrid: some View {
+        Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+            GridRow {
+                metric(recorder.currentDuration.timerText, label: "Time", systemImage: "timer")
+                metric(recorder.currentDistanceMeters.distanceText, label: "Distance", systemImage: "map")
+            }
+
+            GridRow {
+                metric("\(recorder.pointCount)", label: "Points", systemImage: "mappin.and.ellipse")
+                metric(accuracyText, label: "GPS", systemImage: gpsSymbol)
+            }
         }
-        .font(.caption2)
     }
 
-    private func metric(_ value: String, label: String) -> some View {
-        VStack(spacing: 2) {
-            Text(value)
+    private var gpsStatus: some View {
+        Label(gpsStatusText, systemImage: gpsSymbol)
+            .font(.caption2)
+            .foregroundStyle(gpsColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+    }
+
+    private var recordingControls: some View {
+        VStack(spacing: 8) {
+            if recorder.phase == .saving {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Saving walk")
+            } else if recorder.isRecording {
+                Button("Stop", systemImage: "stop.fill") {
+                    Task {
+                        await recorder.stopAndSave()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .controlSize(.large)
+                .accessibilityHint("Stops and saves the current Watch walk.")
+
+                Button("Discard", role: .destructive) {
+                    Task {
+                        await recorder.discard()
+                    }
+                }
                 .font(.caption)
-                .monospacedDigit()
-            Text(label)
-                .foregroundStyle(.secondary)
+                .accessibilityHint("Deletes the current unsaved Watch walk.")
+            } else {
+                Button("Start", systemImage: "figure.walk") {
+                    Task {
+                        await recorder.start(in: modelContext)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .controlSize(.large)
+                .disabled(recorder.canStartRecording == false)
+                .accessibilityHint("Starts a GPS-only Watch walk.")
+            }
         }
-        .frame(maxWidth: .infinity)
+    }
+
+    private func metric(_ value: String, label: String, systemImage: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Label(label, systemImage: systemImage)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
+        .padding(8)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var statusSymbol: String {
+        switch recorder.phase {
+        case .ready:
+            if isLocationAccessDenied {
+                "location.slash.circle.fill"
+            } else if recorder.lastCompletedAt != nil {
+                "checkmark.circle.fill"
+            } else {
+                "figure.walk.circle"
+            }
+        case .recording:
+            "figure.walk.circle.fill"
+        case .saving:
+            "icloud.and.arrow.up.fill"
+        }
+    }
+
+    private var statusColor: Color {
+        switch recorder.phase {
+        case .ready:
+            if isLocationAccessDenied {
+                .orange
+            } else if recorder.lastCompletedAt != nil {
+                .blue
+            } else {
+                .secondary
+            }
+        case .recording:
+            .green
+        case .saving:
+            .blue
+        }
+    }
+
+    private var gpsStatusText: String {
+        switch recorder.authorizationStatus {
+        case .notDetermined:
+            return "Location permission pending"
+        case .denied, .restricted:
+            return "Location access unavailable"
+        default:
+            guard let latestAccuracyMeters = recorder.latestAccuracyMeters else {
+                return recorder.isRecording ? "Waiting for GPS fix" : "GPS ready"
+            }
+
+            if latestAccuracyMeters > WatchRecordingSession.maximumHorizontalAccuracy {
+                return "Poor GPS signal"
+            }
+
+            return "GPS signal good"
+        }
+    }
+
+    private var gpsSymbol: String {
+        if isLocationAccessDenied {
+            return "location.slash"
+        }
+
+        guard recorder.latestAccuracyMeters != nil else {
+            return "location"
+        }
+
+        return isPoorGPS ? "exclamationmark.triangle.fill" : "location.fill"
+    }
+
+    private var gpsColor: Color {
+        if isLocationAccessDenied || isPoorGPS {
+            return .orange
+        }
+
+        return recorder.isRecording ? .green : .secondary
+    }
+
+    private var accuracyText: String {
+        guard let latestAccuracyMeters = recorder.latestAccuracyMeters else {
+            return "--"
+        }
+
+        return "\(Int(latestAccuracyMeters.rounded())) m"
+    }
+
+    private var isPoorGPS: Bool {
+        guard let latestAccuracyMeters = recorder.latestAccuracyMeters else {
+            return false
+        }
+
+        return latestAccuracyMeters > WatchRecordingSession.maximumHorizontalAccuracy
+    }
+
+    private var isLocationAccessDenied: Bool {
+        recorder.authorizationStatus == .denied || recorder.authorizationStatus == .restricted
     }
 }
 

--- a/ASMRWalk Watch App/Features/Recording/WatchRecorder.swift
+++ b/ASMRWalk Watch App/Features/Recording/WatchRecorder.swift
@@ -76,6 +76,7 @@ final class WatchRecorder {
     private(set) var currentDuration: TimeInterval = 0
     private(set) var currentDistanceMeters: Double = 0
     private(set) var pointCount = 0
+    private(set) var lastCompletedAt: Date?
 
     private let locationClient: any WatchLocationClient
     private let requiresLocationUsageDescription: Bool
@@ -107,7 +108,13 @@ final class WatchRecorder {
     var statusTitle: String {
         switch phase {
         case .ready:
-            isLocationAccessDenied ? "Location Needed" : "Ready"
+            if isLocationAccessDenied {
+                "Location Needed"
+            } else if lastCompletedAt != nil {
+                "Saved"
+            } else {
+                "Ready"
+            }
         case .recording:
             "Recording"
         case .saving:
@@ -126,6 +133,9 @@ final class WatchRecorder {
         case .denied, .restricted:
             return "Enable location access in Settings to record Watch walks."
         default:
+            if let lastCompletedAt, phase == .ready {
+                return "Saved \(lastCompletedAt.formatted(date: .omitted, time: .shortened)). Waiting for iCloud sync."
+            }
             if let latestAccuracyMeters {
                 return "GPS accuracy: \(Int(latestAccuracyMeters.rounded())) m"
             }
@@ -143,6 +153,7 @@ final class WatchRecorder {
         }
 
         errorMessage = nil
+        lastCompletedAt = nil
         authorizationStatus = locationClient.authorizationStatus
 
         guard requiresLocationUsageDescription == false || WatchLocationUsageConfiguration.hasWhenInUseUsageDescription else {
@@ -198,6 +209,7 @@ final class WatchRecorder {
                 try await persistence.save(snapshot)
             }
             reset()
+            lastCompletedAt = .now
         } catch {
             phase = .recording
             errorMessage = "Unable to save walk: \(error.localizedDescription)"
@@ -214,6 +226,7 @@ final class WatchRecorder {
             try? await persistence?.deleteRecording(id: recordingID)
         }
 
+        lastCompletedAt = nil
         reset()
     }
 
@@ -314,6 +327,7 @@ final class WatchRecorder {
         updateTask = nil
         clockTask?.cancel()
         clockTask = nil
+        errorMessage = nil
         session = nil
         persistence = nil
         phase = .ready

--- a/ASMRWalk Watch AppTests/ASMRWalk_Watch_AppTests.swift
+++ b/ASMRWalk Watch AppTests/ASMRWalk_Watch_AppTests.swift
@@ -102,6 +102,21 @@ struct ASMRWalk_Watch_AppTests {
         #expect(recorder.isRecording == false)
     }
 
+    @Test("Watch recorder shows sync-pending state after saving")
+    func watchRecorderShowsSyncPendingAfterSaving() async throws {
+        let container = try makeTestContainer()
+        let locationClient = FakeWatchLocationClient(authorizationStatus: .authorizedWhenInUse)
+        let recorder = WatchRecorder(locationClient: locationClient, requiresLocationUsageDescription: false)
+
+        await recorder.start(in: container.mainContext)
+        await recorder.stopAndSave()
+
+        #expect(recorder.isRecording == false)
+        #expect(recorder.lastCompletedAt != nil)
+        #expect(recorder.statusTitle == "Saved")
+        #expect(recorder.statusDetail.contains("Waiting for iCloud sync"))
+    }
+
     private func makeLocation(
         latitude: CLLocationDegrees,
         longitude: CLLocationDegrees,

--- a/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
+++ b/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
@@ -23,14 +23,15 @@ final class ASMRWalk_Watch_AppUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testRecordingScreenLaunches() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // XCUIAutomation Documentation
-        // https://developer.apple.com/documentation/xcuiautomation
+        XCTAssertTrue(app.buttons["Start"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Time"].exists)
+        XCTAssertTrue(app.staticTexts["Distance"].exists)
+        XCTAssertTrue(app.staticTexts["Points"].exists)
+        XCTAssertTrue(app.staticTexts["GPS"].exists)
     }
 
     @MainActor

--- a/Journal.md
+++ b/Journal.md
@@ -399,6 +399,12 @@ Issue 85 gives the Watch app the same visual handshake as the iPhone app. The iP
 
 This is small, but it matters. App icons are the front door people use before they read a single line of UI, and mismatched Watch and iPhone icons make the companion app feel like a side quest instead of part of the same product.
 
+### A Tiny Dashboard Has to Say a Lot
+
+Issue 68 turns the Watch recorder from a working engine into something a person can actually steer from their wrist. The screen now leads with state, then live numbers, then one obvious action. That order matters on watchOS because there is no room for a cockpit full of switches: the user needs to know whether the Watch is ready, recording, saving, waiting for GPS, blocked by location permission, or simply waiting for iCloud to carry the saved walk back home.
+
+The recorder also learned one small bit of memory. After a stop/save finishes, it keeps a short "Saved" state instead of snapping back to plain ready. That gives the user a visible handoff moment: the walk is stored, and sync is the next step.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- Replace the basic Watch starter screen with a compact recording dashboard for state, live metrics, GPS quality, and recording controls.
- Add a post-save `Saved` state so completed Watch walks visibly wait for iCloud sync instead of immediately looking idle.
- Add focused Watch recorder coverage for the sync-pending state and update the Watch UI smoke test to verify the recording screen launches.
- Document the Watch dashboard decision in `Journal.md`.

## Testing
- Xcode MCP `XcodeRefreshCodeIssuesInFile`: passed for changed Swift files.
- Xcode MCP `BuildProject`: passed.
- `git diff --check`: passed.
- Attempted `xcodebuild test -scheme "ASMRWalk Watch App" -destination "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)" -only-testing:"ASMRWalk Watch AppTests"`: blocked by CoreSimulatorService; xcodebuild could not enumerate concrete Watch simulator devices.
- Attempted the same narrow test run with `Any watchOS Simulator Device`: blocked for the same CoreSimulatorService/device enumeration reason.

## Beta tester notes
- Please verify the Watch app opens to the recording dashboard.
- Start a Watch walk and confirm elapsed time, distance, point count, and GPS status update while moving.
- Stop the walk and confirm the screen shows `Saved` / waiting for iCloud sync before returning to normal use.
- Deny or disable location access and confirm the Watch UI clearly shows location is unavailable.

Closes #68.