### PR TITLE
Move Watch recording controls above metrics

### DIFF
--- a/ASMRWalk Watch App/ContentView.swift
+++ b/ASMRWalk Watch App/ContentView.swift
@@ -16,9 +16,10 @@ struct ContentView: View {
         ScrollView {
             VStack(spacing: 12) {
                 statusHeader
+                primaryRecordingControl
                 metricsGrid
                 gpsStatus
-                recordingControls
+                secondaryRecordingControl
             }
             .padding(.horizontal)
             .padding(.vertical, 10)
@@ -72,13 +73,14 @@ struct ContentView: View {
             .accessibilityElement(children: .combine)
     }
 
-    private var recordingControls: some View {
-        VStack(spacing: 8) {
-            if recorder.phase == .saving {
+    private var primaryRecordingControl: some View {
+        Group {
+            switch recorder.phase {
+            case .saving:
                 ProgressView()
                     .controlSize(.small)
                     .accessibilityLabel("Saving walk")
-            } else if recorder.isRecording {
+            case .recording:
                 Button("Stop", systemImage: "stop.fill") {
                     Task {
                         await recorder.stopAndSave()
@@ -88,15 +90,7 @@ struct ContentView: View {
                 .tint(.red)
                 .controlSize(.large)
                 .accessibilityHint("Stops and saves the current Watch walk.")
-
-                Button("Discard", role: .destructive) {
-                    Task {
-                        await recorder.discard()
-                    }
-                }
-                .font(.caption)
-                .accessibilityHint("Deletes the current unsaved Watch walk.")
-            } else {
+            case .ready:
                 Button("Start", systemImage: "figure.walk") {
                     Task {
                         await recorder.start(in: modelContext)
@@ -108,6 +102,19 @@ struct ContentView: View {
                 .disabled(recorder.canStartRecording == false)
                 .accessibilityHint("Starts a GPS-only Watch walk.")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var secondaryRecordingControl: some View {
+        if recorder.isRecording {
+            Button("Discard", role: .destructive) {
+                Task {
+                    await recorder.discard()
+                }
+            }
+            .font(.caption)
+            .accessibilityHint("Deletes the current unsaved Watch walk.")
         }
     }
 

--- a/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
+++ b/ASMRWalk Watch AppUITests/ASMRWalk_Watch_AppUITests.swift
@@ -32,6 +32,7 @@ final class ASMRWalk_Watch_AppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Distance"].exists)
         XCTAssertTrue(app.staticTexts["Points"].exists)
         XCTAssertTrue(app.staticTexts["GPS"].exists)
+        XCTAssertLessThan(app.buttons["Start"].frame.minY, app.staticTexts["Time"].frame.minY)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Move the Watch Start/Stop control directly below the status header so the primary action appears above the metrics.
- Keep the Discard action below the recording data as the secondary/destructive action.
- Add a UI smoke assertion that Start renders vertically above the Time metric.

## Testing
- Xcode MCP `XcodeRefreshCodeIssuesInFile`: passed for `ASMRWalk Watch App/ContentView.swift`.
- Xcode MCP `BuildProject`: passed.
- `git diff --check`: passed.
- UI tests were not run from this session because recent `xcodebuild test` attempts are blocked by CoreSimulatorService/device enumeration.

## Beta tester notes
- On Watch, confirm Start is visible near the top of the screen before the metric data.
- While recording, confirm Stop replaces Start in the same near-top position.
- Confirm Discard remains available below the metrics and is not the primary above-the-fold action.

Closes #89.