### PR TITLE
Show synced Watch recordings in iPhone History

### DIFF
--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -162,6 +162,7 @@ private struct RecordingRow: View {
                 HStack(spacing: 12) {
                     Label(recording.durationText, systemImage: "clock")
                     Label(recording.distanceText, systemImage: "figure.walk")
+                    Label(recording.sourceTitle, systemImage: recording.sourceSystemImage)
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -173,11 +174,6 @@ private struct RecordingRow: View {
 }
 
 private extension WalkRecording {
-    var needsRouteThumbnailRefresh: Bool {
-        points.count > 1
-            && (localThumbnailFileExists == false || thumbnailStyleVersion < WalkRouteThumbnailGenerator.styleVersion)
-    }
-
     var snapshotForThumbnailGeneration: WalkRecordingSnapshot {
         WalkRecordingSnapshot(
             id: id,

--- a/ASMR Walk/Features/History/RecordingDetailView.swift
+++ b/ASMR Walk/Features/History/RecordingDetailView.swift
@@ -32,9 +32,19 @@ struct RecordingDetailView: View {
                         .font(.headline)
                         .foregroundStyle(recording.hasVideo ? .red : .green)
 
+                    Label(recording.sourceTitle, systemImage: recording.sourceSystemImage)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
                     Text(recording.createdAt, format: .dateTime.weekday(.wide).month(.wide).day().year())
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+
+                    if recording.isWatchRecording {
+                        Label(recording.sourceSyncMessage, systemImage: "icloud")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 recordingMetadataCard

--- a/ASMR Walk/Models/WalkRecording+Presentation.swift
+++ b/ASMR Walk/Models/WalkRecording+Presentation.swift
@@ -58,8 +58,31 @@ extension WalkRecording {
         source.title
     }
 
+    var sourceSystemImage: String {
+        switch source {
+        case .iPhone:
+            "iphone"
+        case .appleWatch:
+            "applewatch"
+        }
+    }
+
+    var sourceSyncMessage: String {
+        switch source {
+        case .iPhone:
+            "Recorded on iPhone."
+        case .appleWatch:
+            "Recorded on Apple Watch. Route data syncs through iCloud."
+        }
+    }
+
     var isWatchRecording: Bool {
         source == .appleWatch
+    }
+
+    var needsRouteThumbnailRefresh: Bool {
+        points.count > 1
+            && (localThumbnailFileExists == false || thumbnailStyleVersion < WalkRouteThumbnailGenerator.styleVersion)
     }
 
     var routeTimingStart: Date {

--- a/ASMR WalkTests/WalkRecordingModelTests.swift
+++ b/ASMR WalkTests/WalkRecordingModelTests.swift
@@ -206,10 +206,56 @@ struct WalkRecordingModelTests {
 
         #expect(recording.source == .appleWatch)
         #expect(recording.sourceTitle == "Apple Watch")
+        #expect(recording.sourceSystemImage == "applewatch")
+        #expect(recording.sourceSyncMessage == "Recorded on Apple Watch. Route data syncs through iCloud.")
         #expect(recording.isWatchRecording)
         #expect(recording.routeTimingStart == startedAt)
         #expect(recording.routeTimingEnd == endedAt)
         #expect(recording.externalCameraTimingMessage == "No external camera timing has been attached.")
+        #expect(recording.videoAvailabilityTitle == "No Video")
+        #expect(recording.videoAvailabilityMessage == "This recording has route data only.")
+    }
+
+    @Test("Synced Watch recordings without local thumbnails request iPhone thumbnail refresh")
+    func syncedWatchRecordingRequestsLocalThumbnailRefresh() {
+        let recording = WalkRecording(
+            title: "Synced Watch Walk",
+            mode: .walk,
+            recordingSource: .appleWatch,
+            thumbnailURL: nil,
+            thumbnailStyleVersion: 0,
+            points: [
+                makePoint(timestamp: 100),
+                makePoint(timestamp: 120, latitude: 33.4490, longitude: -112.0730)
+            ]
+        )
+
+        #expect(recording.needsRouteThumbnailRefresh)
+    }
+
+    @Test("Synced Watch recordings keep current local thumbnails")
+    func syncedWatchRecordingKeepsCurrentLocalThumbnail() throws {
+        let thumbnailURL = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+            .appendingPathExtension("jpg")
+        try Data([0xFF, 0xD8, 0xFF, 0xD9]).write(to: thumbnailURL)
+        defer {
+            try? FileManager.default.removeItem(at: thumbnailURL)
+        }
+
+        let recording = WalkRecording(
+            title: "Synced Watch Walk",
+            mode: .walk,
+            recordingSource: .appleWatch,
+            thumbnailURL: thumbnailURL,
+            thumbnailStyleVersion: WalkRouteThumbnailGenerator.styleVersion,
+            points: [
+                makePoint(timestamp: 100),
+                makePoint(timestamp: 120, latitude: 33.4490, longitude: -112.0730)
+            ]
+        )
+
+        #expect(recording.needsRouteThumbnailRefresh == false)
     }
 
     @Test("External camera timing describes its route offset")

--- a/Journal.md
+++ b/Journal.md
@@ -405,6 +405,12 @@ Issue 68 turns the Watch recorder from a working engine into something a person 
 
 The recorder also learned one small bit of memory. After a stop/save finishes, it keeps a short "Saved" state instead of snapping back to plain ready. That gives the user a visible handoff moment: the walk is stored, and sync is the next step.
 
+### Watch Walks Need a Passport Stamp
+
+Issue 69 is the iPhone side of the handshake. Once CloudKit brings a Watch-created `WalkRecording` home, History should not treat it like a mystery iPhone walk. Rows and detail screens now show the source, Watch route-only recordings keep the "no video" story clean, and missing local thumbnails are explicitly eligible for regeneration on the iPhone.
+
+That last bit is subtle but important: a thumbnail URL is a local file path, not a portable souvenir. When a Watch recording syncs to the phone, the route points are the durable truth; the thumbnail is rebuilt locally from those points.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- Show the recording source in iPhone History rows and Recording Detail so Watch-origin walks are clearly identified after CloudKit sync.
- Add a Watch sync context message in detail for route-only Watch recordings.
- Move thumbnail refresh eligibility into model presentation so synced Watch rows with route points and no local thumbnail are explicitly eligible for iPhone-side thumbnail regeneration.
- Add model coverage for Watch route-only presentation and local thumbnail refresh behavior.
- Update `Journal.md` with the Watch-to-iPhone sync presentation boundary.

## Testing
- Xcode MCP `XcodeRefreshCodeIssuesInFile`: passed for changed Swift files.
- Xcode MCP `BuildProject`: passed.
- `git diff --check`: passed.
- Attempted `xcodebuild test -scheme "ASMR Walk" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"ASMR WalkTests/WalkRecordingModelTests"`: blocked before launch because CoreSimulatorService could not enumerate a concrete iPhone 17 Pro simulator; xcodebuild only reported placeholder simulator destinations.

## Manual validation notes
- Record a Watch walk, let it sync through iCloud, then confirm it appears in iPhone History with source `Apple Watch`.
- Open the synced recording and confirm Detail shows the Apple Watch source and iCloud route sync context.
- Confirm route-only Watch recordings do not show video availability warnings or Save Video to Photos controls.
- Confirm a route thumbnail appears after iPhone-side generation once route points have synced.

Closes #69.