### PR TITLE
Support Watch external camera timing export

### DIFF
--- a/ASMR Walk/ContentView.swift
+++ b/ASMR Walk/ContentView.swift
@@ -57,6 +57,8 @@ enum AccessibilityID {
     static let exportRecordingButton = "history.exportRecordingButton"
     static let editRecordingMetadataButton = "history.editRecordingMetadataButton"
     static let saveRecordingMetadataButton = "history.saveRecordingMetadataButton"
+    static let editExternalCameraTimingButton = "history.editExternalCameraTimingButton"
+    static let saveExternalCameraTimingButton = "history.saveExternalCameraTimingButton"
     static let saveVideoToPhotosButton = "history.saveVideoToPhotosButton"
     static let videoPlayback = "history.videoPlayback"
     static let videoRouteOverlay = "history.videoRouteOverlay"

--- a/ASMR Walk/Features/History/RecordingDetailView.swift
+++ b/ASMR Walk/Features/History/RecordingDetailView.swift
@@ -13,6 +13,7 @@ struct RecordingDetailView: View {
     @State private var photoSaveStatus: PhotoSaveStatus?
     @State private var isSavingVideoToPhotos = false
     @State private var isShowingMetadataEditor = false
+    @State private var isShowingExternalCameraEditor = false
 
     var body: some View {
         ScrollView {
@@ -67,6 +68,10 @@ struct RecordingDetailView: View {
                     )
                 }
 
+                if recording.isWatchRecording {
+                    externalCameraTimingCard
+                }
+
                 if recording.hasVideo {
                     Label(recording.videoAvailabilityMessage, systemImage: recording.localVideoFileExists ? "video.fill" : "video.slash")
                         .font(.subheadline)
@@ -94,6 +99,9 @@ struct RecordingDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $isShowingMetadataEditor) {
             RecordingMetadataEditView(recording: recording)
+        }
+        .sheet(isPresented: $isShowingExternalCameraEditor) {
+            ExternalCameraTimingEditView(recording: recording)
         }
         .alert("Video Export", isPresented: isShowingPhotoSaveStatus) {
             Button("OK", role: .cancel) {
@@ -148,6 +156,38 @@ struct RecordingDetailView: View {
         }
 
         return UIImage(contentsOfFile: thumbnailURL.path)
+    }
+
+    private var externalCameraTimingCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Label("External Camera", systemImage: "video.fill")
+                    .font(.headline)
+
+                Spacer()
+
+                Button(recording.externalVideoStartedAt == nil ? "Add" : "Edit", systemImage: "pencil") {
+                    isShowingExternalCameraEditor = true
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier(AccessibilityID.editExternalCameraTimingButton)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(recording.externalCameraWorkflowMessage)
+                    .font(.subheadline)
+
+                Text(recording.externalCameraTimingMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("External footage stays outside ASMR Walk; GPX export includes only the clip label and timing metadata.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(.quaternary, in: .rect(cornerRadius: 16))
     }
 
     private var recordingMetadataCard: some View {
@@ -366,6 +406,96 @@ private struct RecordingMetadataEditView: View {
             recording.descriptionEditedAt = editedAt
         }
 
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            saveErrorMessage = error.localizedDescription
+            isShowingSaveError = true
+        }
+    }
+}
+
+private struct ExternalCameraTimingEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var recording: WalkRecording
+    @State private var externalVideoReference: String
+    @State private var externalVideoStartedAt: Date
+    @State private var saveErrorMessage = ""
+    @State private var isShowingSaveError = false
+
+    init(recording: WalkRecording) {
+        self.recording = recording
+        _externalVideoReference = State(initialValue: recording.externalVideoReference ?? "")
+        _externalVideoStartedAt = State(initialValue: recording.externalVideoStartedAt ?? recording.routeTimingStart)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Clip label", text: $externalVideoReference)
+                        .textInputAutocapitalization(.words)
+
+                    DatePicker(
+                        "Camera Start",
+                        selection: $externalVideoStartedAt,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                } footer: {
+                    Text("Use a clip name, camera filename, or slate note. ASMR Walk stores timing metadata only; it does not import the external video file.")
+                }
+
+                if recording.externalVideoStartedAt != nil || recording.externalVideoReference?.isEmpty == false {
+                    Section {
+                        Button("Clear External Camera Timing", role: .destructive) {
+                            clear()
+                        }
+                    }
+                }
+            }
+            .navigationTitle("External Camera")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        save()
+                    }
+                    .accessibilityIdentifier(AccessibilityID.saveExternalCameraTimingButton)
+                }
+            }
+            .alert("Unable to Save Timing", isPresented: $isShowingSaveError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(saveErrorMessage)
+            }
+        }
+    }
+
+    private var trimmedReference: String {
+        externalVideoReference.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func save() {
+        recording.externalVideoReference = trimmedReference.isEmpty ? nil : trimmedReference
+        recording.externalVideoStartedAt = externalVideoStartedAt
+        saveAndDismiss()
+    }
+
+    private func clear() {
+        recording.externalVideoReference = nil
+        recording.externalVideoStartedAt = nil
+        saveAndDismiss()
+    }
+
+    private func saveAndDismiss() {
         do {
             try modelContext.save()
             dismiss()

--- a/ASMR Walk/Features/History/WalkRouteExport.swift
+++ b/ASMR Walk/Features/History/WalkRouteExport.swift
@@ -135,6 +135,7 @@ struct WalkRouteExport {
         }
         if let externalVideoStartedAt {
             values += "<asmrwalk:externalVideoStartedAt>\(externalVideoStartedAt.ISO8601Format())</asmrwalk:externalVideoStartedAt>"
+            values += "<asmrwalk:externalVideoOffsetSeconds>\(externalVideoStartedAt.timeIntervalSince(routeStartedAt).gpxNumberText)</asmrwalk:externalVideoOffsetSeconds>"
         }
         return values
     }

--- a/ASMR Walk/Models/WalkRecording+Presentation.swift
+++ b/ASMR Walk/Models/WalkRecording+Presentation.swift
@@ -110,6 +110,18 @@ extension WalkRecording {
         return "External camera timing starts \(abs(offset).timerText) before the route."
     }
 
+    var externalCameraWorkflowMessage: String {
+        if let externalVideoReference, externalVideoReference.isEmpty == false {
+            return "External clip: \(externalVideoReference)"
+        }
+
+        if externalVideoStartedAt != nil {
+            return "External camera timing is attached."
+        }
+
+        return "Attach a clip label and start time for footage recorded outside ASMR Walk."
+    }
+
     var titleConflictTimestamp: Date? {
         guard isTitleUserEdited else {
             return nil

--- a/ASMR WalkTests/RouteExportTests.swift
+++ b/ASMR WalkTests/RouteExportTests.swift
@@ -121,8 +121,11 @@ struct RouteExportTests {
         #expect(gpxText.contains("<asmrwalk:captureDeviceName>David&apos;s Apple Watch &amp; Camera</asmrwalk:captureDeviceName>"))
         #expect(gpxText.contains("<asmrwalk:routeStartedAt>1970-01-01T00:16:40Z</asmrwalk:routeStartedAt>"))
         #expect(gpxText.contains("<asmrwalk:routeEndedAt>1970-01-01T00:20:40Z</asmrwalk:routeEndedAt>"))
+        #expect(gpxText.contains("<asmrwalk:hasVideo>false</asmrwalk:hasVideo>"))
         #expect(gpxText.contains("<asmrwalk:externalVideoReference>A-cam &lt;clip 12&gt;</asmrwalk:externalVideoReference>"))
         #expect(gpxText.contains("<asmrwalk:externalVideoStartedAt>1970-01-01T00:16:35Z</asmrwalk:externalVideoStartedAt>"))
+        #expect(gpxText.contains("<asmrwalk:externalVideoOffsetSeconds>-5</asmrwalk:externalVideoOffsetSeconds>"))
+        #expect(gpxText.contains("clip 12.mov") == false)
     }
 
     @Test("GPX export includes recording descriptions")

--- a/ASMR WalkTests/WalkRecordingModelTests.swift
+++ b/ASMR WalkTests/WalkRecordingModelTests.swift
@@ -212,6 +212,7 @@ struct WalkRecordingModelTests {
         #expect(recording.routeTimingStart == startedAt)
         #expect(recording.routeTimingEnd == endedAt)
         #expect(recording.externalCameraTimingMessage == "No external camera timing has been attached.")
+        #expect(recording.externalCameraWorkflowMessage == "Attach a clip label and start time for footage recorded outside ASMR Walk.")
         #expect(recording.videoAvailabilityTitle == "No Video")
         #expect(recording.videoAvailabilityMessage == "This recording has route data only.")
     }
@@ -273,6 +274,7 @@ struct WalkRecordingModelTests {
         )
 
         #expect(recording.externalVideoReference == "A-cam clip 012")
+        #expect(recording.externalCameraWorkflowMessage == "External clip: A-cam clip 012")
         #expect(recording.externalCameraTimingMessage == "External camera timing starts 0:05 before the route.")
     }
 

--- a/Journal.md
+++ b/Journal.md
@@ -411,6 +411,12 @@ Issue 69 is the iPhone side of the handshake. Once CloudKit brings a Watch-creat
 
 That last bit is subtle but important: a thumbnail URL is a local file path, not a portable souvenir. When a Watch recording syncs to the phone, the route points are the durable truth; the thumbnail is rebuilt locally from those points.
 
+### External Camera Footage Gets a Timing Slip
+
+Issue 70 keeps the external-camera workflow honest. ASMR Walk is not importing or storing the camera footage here; it is writing down the useful handshake details: the clip label, when that clip started, when the route started, and the offset between the two. That is enough for the Mac importer and future FCP workflow to line up the walking route with separately recorded footage.
+
+The key rule is to export metadata, not private files. GPX carries route points, source, timing, and the optional external clip label, but no sandbox video paths. The phone detail screen also says that plainly so a Watch route paired with an outside camera never looks like ASMR Walk secretly has the footage.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- Add a Watch-only External Camera section in Recording Detail for attaching an external clip label and camera start time.
- Keep the workflow metadata-only: ASMR Walk stores no external footage and does not import or match camera files in this issue.
- Export `externalVideoOffsetSeconds` in GPX alongside the existing Watch source, route timing, capture device, external clip label, and external start time fields.
- Add presentation/test coverage for Watch route-only external-camera messaging and GPX timing metadata.
- Document the external-camera timing boundary in `Journal.md`.

## Testing
- Xcode MCP `XcodeRefreshCodeIssuesInFile`: passed for changed app/model files and `WalkRecordingModelTests.swift`; Xcode SourceEditor diagnostics failed for `RouteExportTests.swift`, so build was used for that file.
- Xcode MCP `BuildProject`: passed.
- `git diff --check`: passed.
- Attempted `xcodebuild test -scheme "ASMR Walk" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"ASMR WalkTests/RouteExportTests" -only-testing:"ASMR WalkTests/WalkRecordingModelTests"`: blocked before launch because CoreSimulatorService could not enumerate a concrete iPhone 17 Pro simulator; xcodebuild only reported placeholder simulator destinations.

## Beta tester notes
- For a Watch-recorded walk, open Recording Detail on iPhone and verify the External Camera section is visible.
- Add a clip label and camera start time, save, then export GPX and confirm the route still exports normally.
- Confirm the UI makes clear that external camera footage stays outside ASMR Walk.
- Full Watch-to-iPhone sync behavior still needs on-device/TestFlight validation under #71 because simulator sync has not been reliable.

Closes #70.