### PR TITLE
Update Watch release validation docs

### DIFF
--- a/APP_STORE_COPY.md
+++ b/APP_STORE_COPY.md
@@ -6,31 +6,35 @@ Public privacy policy URL: https://bald-traveler.com/asmr-walk-privacy-policy/
 
 ## Short Description
 
-ASMR Walk is an iPhone walking journal for recording GPS routes, optional video walks, iCloud-synced route history, and GPX route exports.
+ASMR Walk is a walking journal for iPhone and Apple Watch with GPS routes, optional iPhone video walks, iCloud-synced route history, and GPX route exports.
 
 ## Description
 
-ASMR Walk helps you capture quiet walking memories on your iPhone. Record a GPS Walk for a simple route journal, or record a Video Walk when you want camera and microphone audio alongside the route.
+ASMR Walk helps you capture quiet walking memories. Record a GPS Walk on iPhone for a simple route journal, record a Video Walk on iPhone when you want camera and microphone audio alongside the route, or use the Apple Watch companion app to record a GPS-only walk from your wrist.
 
-Saved walk metadata and routes can sync through your private iCloud account. Video walks are stored in ASMR Walk on the device where they were recorded for playback with the saved route, and you can save a copy to Photos from the History detail screen. Full video files do not sync to other devices through ASMR Walk.
+Saved walk metadata and routes can sync through your private iCloud account. Watch recordings appear in iPhone History after sync with an Apple Watch source label. Video walks are stored in ASMR Walk on the device where they were recorded for playback with the saved route, and you can save a copy to Photos from the History detail screen. Full video files do not sync to other devices through ASMR Walk.
 
 After a walk is saved, ASMR Walk can generate a route thumbnail and use Apple Maps place information to suggest a useful title and description, which you can edit from the History detail screen. Deleting an ASMR Walk recording removes the route, app metadata, app-managed thumbnail, and app-managed video file on that device, but it does not delete any copy you chose to save to Photos.
 
-ASMR Walk can export full-fidelity GPX files through the iOS share sheet, including recording descriptions when present, and can create Google Maps walking-route links for quick sharing.
+ASMR Walk can export full-fidelity GPX files through the iOS share sheet, including recording descriptions when present, and can create Google Maps walking-route links for quick sharing. Watch routes can also store external-camera timing notes on iPhone, so a route can be aligned later with separately recorded footage.
 
 Background GPS recording is optional and applies only to GPS Walk recordings. It requires the user to enable Background GPS Recording in Settings and grant Always location permission. Video Walk recording is foreground-only and stops when the app leaves the foreground.
 
-Version 1.1.0 is iPhone-only and requires iOS 26.0 or later. iPad, Apple Watch, HealthKit, developer-operated accounts, analytics, advertising, and developer-operated backend storage are not included in version 1.1.0.
+Version 1.1.0 requires iOS 26.0 or later for the iPhone app and includes a GPS-only Apple Watch companion app. iPad, HealthKit workouts, developer-operated accounts, analytics, advertising, and developer-operated backend storage are not included in version 1.1.0.
 
 ## Keywords
 
-walking, GPS, route, GPX, video walk, walking journal, map, iCloud
+walking, GPS, route, GPX, video walk, Apple Watch, walking journal, map, iCloud
 
 ## Review Notes
 
 - Background location is used only for GPS Walk recordings.
 - Background GPS requires the user to enable Background GPS Recording in Settings and grant Always location permission.
 - Video Walk recordings stop when the app leaves the foreground.
+- The Apple Watch companion app records GPS-only walks. It does not record video or HealthKit workouts in version 1.1.0.
+- Watch recordings sync route metadata and points through the user's private iCloud database and appear in iPhone History after sync.
+- Watch-to-iPhone sync is being validated on physical Watch/iPhone hardware before App Store submission because Simulator sync was not reliable during development.
+- External-camera timing fields are notes for separately captured footage; ASMR Walk does not import or sync the external video file.
 - Finished video walks are stored locally in ASMR Walk by default.
 - Route data and recording metadata sync through the user's private iCloud database.
 - Full video files do not sync to other devices through ASMR Walk.

--- a/Journal.md
+++ b/Journal.md
@@ -417,6 +417,12 @@ Issue 70 keeps the external-camera workflow honest. ASMR Walk is not importing o
 
 The key rule is to export metadata, not private files. GPX carries route points, source, timing, and the optional external clip label, but no sandbox video paths. The phone detail screen also says that plainly so a Watch route paired with an outside camera never looks like ASMR Walk secretly has the footage.
 
+### Release Notes Are the Trail Signs
+
+Issue 71 is the point where the Watch work stops being a stack of merged features and becomes a release story. The docs now say the current truth in one voice: 1.1.0 includes an Apple Watch companion app, but the Watch records GPS-only routes. It does not record video, it does not create HealthKit workouts, and it relies on the user's private iCloud account to bring completed routes back to iPhone History.
+
+The simulator taught one more release lesson: some workflows can compile, unit test, and still need real hardware before they are release facts. Watch-to-iPhone CloudKit sync was not reliable in Simulator, so the checklist treats physical Watch/iPhone validation as an App Store submission gate instead of pretending the simulator run settled it. Think of issue #93 as the final trail marker at the parking lot: #71 can prepare the map, but the release should not leave without checking that marker off.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -62,4 +62,4 @@ ASMR Walk does not track users across apps or websites.
 
 ## Contact
 
-For privacy questions, contact `heathdj@me.com`.
+For privacy questions, contact `support@bald-traveler.com`.

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,8 +1,8 @@
 # ASMR Walk Privacy Policy
 
-Last updated: August 26, 2026
+Last updated: August 30, 2026
 
-ASMR Walk is designed as a private walking journal. The app records walking routes and optional video walks on your iPhone. ASMR Walk does not run a developer-operated account system, analytics service, advertising network, or backend server.
+ASMR Walk is designed as a private walking journal. The app records walking routes, optional video walks on your iPhone, and GPS-only walks from the Apple Watch companion app. ASMR Walk does not run a developer-operated account system, analytics service, advertising network, or backend server.
 
 ## Data Stored On Your Device
 
@@ -12,9 +12,9 @@ Route points can include latitude, longitude, timestamp, altitude when available
 
 ## iCloud Sync
 
-ASMR Walk can sync recording metadata and route data through your private iCloud database using Apple's CloudKit service. This lets recordings created on one signed-in device appear on another signed-in device.
+ASMR Walk can sync recording metadata and route data through your private iCloud database using Apple's CloudKit service. This lets recordings created on one signed-in device, including Apple Watch GPS recordings, appear on another signed-in device.
 
-iCloud sync can include walk titles, descriptions, dates, durations, distances, route points, generated place metadata, route thumbnail references, and export-related metadata. Full video files are not synced by ASMR Walk. Video walks remain stored in app-managed local storage on the device where they were recorded unless you choose to save or share a copy.
+iCloud sync can include walk titles, descriptions, dates, durations, distances, route points, recording source, generated place metadata, route thumbnail references, and export-related metadata. For Watch routes paired with footage from a separate camera, export-related metadata can include an external clip label and timing values used to align the route with that separate footage. Full video files are not synced by ASMR Walk. Video walks remain stored in app-managed local storage on the device where they were recorded unless you choose to save or share a copy.
 
 Your iCloud account and Apple's CloudKit service are operated by Apple, not ASMR Walk. ASMR Walk does not run its own sync server.
 
@@ -22,13 +22,15 @@ Your iCloud account and Apple's CloudKit service are operated by Apple, not ASMR
 
 ASMR Walk uses location while recording to draw and save your walking route.
 
-Background GPS recording is optional, applies only to GPS Walk recordings, and requires Always location permission. When enabled, ASMR Walk may continue recording a GPS-only walk while the app is backgrounded or the screen is locked. Video Walks do not continue recording in the background.
+On Apple Watch, ASMR Walk uses location only for GPS-only Watch walk recording. The Watch app asks for location access when you start recording from the Watch.
+
+Background GPS recording is optional on iPhone, applies only to iPhone GPS Walk recordings, and requires Always location permission. When enabled, ASMR Walk may continue recording a GPS-only walk while the iPhone app is backgrounded or the screen is locked. Video Walks do not continue recording in the background.
 
 After a recording is saved, ASMR Walk may use Apple's MapKit services to generate a route thumbnail and suggest a place-based title and description. This work is best-effort and is used only to improve the local recording details shown in the app.
 
 ## Camera And Microphone
 
-ASMR Walk uses the camera and microphone only for Video Walk recording. Video capture happens on your device.
+ASMR Walk uses the camera and microphone only for iPhone Video Walk recording. Video capture happens on your device. Apple Watch recordings do not use the camera or microphone.
 
 ## Photos
 
@@ -43,6 +45,7 @@ Photos may use Apple's own services, such as iCloud Photos, depending on your de
 ASMR Walk can create exports when you choose to share them:
 
 - GPX files include route points and ASMR Walk metadata such as recording duration, recording mode, recording description, video presence, recording ID, horizontal accuracy, and speed when available.
+- For Watch routes paired with an external camera, GPX files may include the external clip label and timing values you entered so other tools can align the route with separately recorded footage.
 - Google Maps route links include the route start, destination, and sampled waypoints.
 
 Sharing is user-initiated through the iOS share sheet. The destination you choose may receive the exported data and apply its own privacy practices.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ASMR Walk
 
-ASMR Walk is an iPhone walking journal built with SwiftUI. It records GPS walking routes, can pair a route with a walk video, syncs recording metadata and route data through iCloud, keeps videos local, and exports routes for use outside the app.
+ASMR Walk is an iPhone walking journal with an Apple Watch companion recorder. It records GPS walking routes, can pair a route with a walk video, syncs recording metadata and route data through iCloud, keeps videos local, and exports routes for use outside the app.
 
 ## Version 1.1.0 Scope
 
-ASMR Walk 1.1.0 is intentionally iPhone-only and uses the user's private iCloud account to sync recording metadata and route data. It supports GPS Walk recordings, Video Walk recordings, optional background GPS for GPS Walk only, local video storage with user-initiated Photos export, synced history metadata/routes, route thumbnails, generated place-based recording details, and route export. It does not include iPad support, Apple Watch, HealthKit, analytics, developer-operated accounts, advertising, developer-operated storage, or a developer-operated backend.
+ASMR Walk 1.1.0 uses the user's private iCloud account to sync recording metadata and route data. It supports iPhone GPS Walk recordings, iPhone Video Walk recordings, Apple Watch GPS-only recordings, optional background GPS for iPhone GPS Walk only, local video storage with user-initiated Photos export, synced history metadata/routes, route thumbnails, generated place-based recording details, external-camera timing metadata for Watch routes, and route export. It does not include iPad support, HealthKit, analytics, developer-operated accounts, advertising, developer-operated storage, or a developer-operated backend.
 
 iCloud library sync is not gated by a StoreKit subscription in this implementation; it is available when the user is signed in to iCloud and CloudKit is available.
 
@@ -14,9 +14,12 @@ iCloud library sync is not gated by a StoreKit subscription in this implementati
 - GPS-only walk recording with a live MapKit route overlay.
 - Optional background GPS recording for GPS-only walks, gated by a Settings toggle and Always location permission.
 - Video walk recording with camera preview, microphone audio, landscape-first UI, and live route overlay.
+- Apple Watch GPS-only recording with live elapsed time, distance, route-point count, GPS status, save, and discard controls.
 - Saved video walk playback with a synchronized route-progress map overlay.
 - SwiftData persistence with private iCloud sync for recording metadata and route points.
 - Recording detail screens with editable titles and descriptions, route maps, duration, distance, route-point counts, and video indicators.
+- Watch recording source labels in iPhone History and Recording Detail.
+- External-camera timing fields for Watch recordings so separately captured footage can be aligned later.
 - Settings iCloud status so users can see whether their private iCloud account is available for library sync.
 - Generated route thumbnails for saved walks in History, detail views, and GPX share previews.
 - Best-effort place metadata generation after saving a walk, with fallback date/time titles when lookup is unavailable.
@@ -34,6 +37,7 @@ iCloud library sync is not gated by a StoreKit subscription in this implementati
 - MapKit for live and saved route maps.
 - Core Location for GPS tracking.
 - AVFoundation for video and microphone capture.
+- watchOS SwiftUI for the Apple Watch companion recorder.
 - Swift Testing for unit tests.
 - XCTest / XCUIAutomation for UI tests.
 
@@ -41,20 +45,26 @@ iCloud library sync is not gated by a StoreKit subscription in this implementati
 
 ```text
 ASMR Walk/
-  Features/
-    History/   Saved recordings, details, route maps, and exports
-    Video/     Camera preview, video capture, landscape video-walk UI
-    Walk/      GPS recording flow and route session logic
-  Models/      SwiftData models and presentation helpers
+  ASMR Walk/
+    Features/
+      History/   Saved recordings, details, route maps, and exports
+      Video/     Camera preview, video capture, landscape video-walk UI
+      Walk/      GPS recording flow and route session logic
+    Models/      SwiftData models and presentation helpers
+  ASMRWalk Watch App/
+    Features/Recording/   Watch GPS recorder, session, and persistence
+    Models/               Watch-side SwiftData models
 ```
 
 ## Requirements
 
 - Xcode with iOS 26 SDK support.
 - iOS 26 iPhone simulator or physical iPhone.
+- watchOS simulator or physical Apple Watch for the companion app.
 - A physical iPhone is recommended for final GPS, camera, and microphone validation.
+- A paired physical Apple Watch and iPhone are required to validate Watch GPS recording and Watch-to-iPhone iCloud sync before App Store submission.
 - An iCloud account and CloudKit-capable provisioning are required to validate sync across devices.
-- Version 1.1.0 is intentionally iPhone-only; iPad support is out of scope until the app receives a full adaptive-layout pass.
+- iPad support is out of scope until the app receives a full adaptive-layout pass.
 
 ## Setup
 
@@ -68,6 +78,8 @@ Before running recording features, confirm the app target includes these generat
 - `Privacy - Microphone Usage Description`
 - `Background Modes`: Location updates and Remote notifications
 - `iCloud`: CloudKit with container `iCloud.com.bald-traveler.ASMRWalk`
+
+The Watch app target should use the same CloudKit container and include a Watch location usage description. Watch recording asks for location access when the user starts a Watch walk.
 
 Expected privacy strings:
 
@@ -85,6 +97,8 @@ iOS will terminate the app if camera or microphone capture is requested without 
 See `RELEASE_CHECKLIST.md` before uploading to App Store Connect.
 
 Finished video walks are kept in ASMR Walk's app-managed storage for playback. iCloud sync carries the recording details and route, not the `.mov` file. From a video walk's History detail screen, the user can save a copy to Photos. Deleting an ASMR Walk recording removes the route, app metadata, and app-managed video file on that device, but it does not delete any Photos copy the user saved.
+
+Apple Watch recordings are GPS-only route recordings. They sync through private iCloud as recording metadata and route points, then appear in iPhone History with an Apple Watch source label. Watch recordings do not include video. If the walk used a separate external camera, the iPhone detail screen can store the external clip label and start time so GPX export carries alignment metadata without importing or syncing the video file.
 
 ## Privacy
 
@@ -105,6 +119,8 @@ Background GPS recording requires the `location` background mode, the Background
 
 iCloud sync requires the CloudKit entitlement, the `iCloud.com.bald-traveler.ASMRWalk` container, and the `remote-notification` background mode. Sync uses the user's private iCloud database and may be temporarily unavailable when the device is signed out of iCloud or iCloud is restricted.
 
+Watch-to-iPhone sync can be unreliable in Simulator and is treated as non-authoritative for release validation. Complete the physical-device validation tracked in GitHub issue #93 before submitting version 1.1.0 to the App Store.
+
 ## Testing
 
 Use Xcode's test action for the `ASMR Walk` scheme.
@@ -116,12 +132,13 @@ The unit test suite covers:
 - Generated and editable recording metadata.
 - Route thumbnail path and persistence helpers.
 - iCloud sync configuration and account-status presentation.
+- Apple Watch recording session filtering, persistence, UI-facing state, and route metadata.
 - GPS route filtering and distance accumulation.
 - Video-walk recording metadata.
 - Google Maps route export.
 - GPX route export.
 
-UI tests cover the main tab surfaces and launch behavior. Camera and microphone flows should be validated on a real device after privacy keys are configured.
+UI tests cover the main tab surfaces and launch behavior. Camera, microphone, outdoor GPS, and Watch-to-iPhone sync flows should be validated on physical devices after privacy keys and entitlements are configured.
 
 The app uses a native static launch screen configured through the target Info settings. It does not show an artificial SwiftUI splash screen after launch.
 
@@ -131,12 +148,14 @@ The app uses a native static launch screen configured through the target Info se
 - The map overlay is rendered in the app and is not burned into exported video.
 - Video Walk does not continue recording in the background.
 - iCloud sync does not sync full video files; videos remain on the recording device unless the user saves or shares a copy.
-- iPad, Apple Watch, and HealthKit are not part of version 1.1.0.
+- Apple Watch recordings are GPS-only and do not record video or HealthKit workouts.
+- Watch-to-iPhone sync needs physical-device/TestFlight validation before App Store submission because Simulator sync has not been reliable.
+- iPad and HealthKit are not part of version 1.1.0.
 
 ## Roadmap
 
 These are future ideas, not shipped 1.1.0 features:
 
 - HealthKit workout integration.
-- Apple Watch companion recording.
 - Burned-in video map overlay export.
+- Shared route/model package for future iPhone, Watch, Mac importer, and Final Cut Pro plugin reuse.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -9,11 +9,15 @@ Use this before uploading `1.1.0` to App Store Connect.
 - [ ] Build number is incremented for every upload.
 - [ ] Generated launch screen is enabled.
 - [ ] App icon is configured.
-- [ ] Targeted device family is iPhone only for version 1.1.0.
+- [ ] iPhone app targeted device family excludes iPad for version 1.1.0.
+- [ ] Apple Watch companion app target is included in the archive.
+- [ ] Apple Watch app icon is configured and visually matches the iPhone app icon.
 - [ ] Supported iPhone orientations include portrait and landscape. The app locks Video Walk to landscape-right at runtime.
 - [ ] iCloud capability is enabled with CloudKit container `iCloud.com.bald-traveler.ASMRWalk`.
+- [ ] Watch app iCloud capability is enabled with CloudKit container `iCloud.com.bald-traveler.ASMRWalk`.
 - [ ] Confirm iCloud library sync is not StoreKit-gated in this release; if product direction changes to Pro/subscription, add entitlement gating before release.
 - [ ] Background Modes includes both Location updates and Remote notifications.
+- [ ] Watch app has a location usage description for GPS-only Watch recording.
 - [ ] Privacy strings are present in the generated target Info settings:
   - [ ] `NSLocationWhenInUseUsageDescription`
   - [ ] `NSLocationAlwaysAndWhenInUseUsageDescription`
@@ -48,11 +52,15 @@ Use this before uploading `1.1.0` to App Store Connect.
 - [ ] Confirm Background GPS Recording is described as optional, user-enabled, and GPS Walk only.
 - [ ] Confirm Settings shows the current iCloud Library status.
 - [ ] Confirm documentation and App Store copy do not imply background video recording.
+- [ ] Confirm documentation and App Store copy describe the Apple Watch app as GPS-only.
+- [ ] Confirm documentation and App Store copy do not imply HealthKit workout recording.
+- [ ] Confirm documentation and App Store copy explain Watch-to-iPhone sync uses the user's private iCloud database.
+- [ ] Confirm documentation and App Store copy explain external-camera timing stores metadata only and does not import or sync external video files.
 - [ ] Confirm About sheet shows app name, version, build, and `heathdj@me.com`.
 
 ## Device Validation
 
-Run these on a physical iPhone before submission:
+Run these on physical devices before submission:
 
 ### Physical Device Only
 
@@ -112,6 +120,24 @@ Run these on a physical iPhone before submission:
 - [ ] Sign out of iCloud or use a restricted iCloud account and confirm Settings explains the sync state without blocking local recording.
 - [ ] Confirm CloudKit schema is initialized in development and promoted before production release.
 
+### Apple Watch Physical Device Gate
+
+- [ ] Confirm GitHub issue #93 is closed before submitting version 1.1.0 to App Store Connect.
+- [ ] Install the iPhone app and Apple Watch app on paired physical devices.
+- [ ] Confirm the iPhone and Apple Watch are signed into the expected iCloud account and iCloud sync is available.
+- [ ] Grant location permission to ASMR Walk on Apple Watch.
+- [ ] Start a GPS-only walk from Apple Watch and confirm elapsed time, distance, route-point count, and GPS status update during the walk.
+- [ ] Stop and save the Watch walk.
+- [ ] Confirm the Watch shows the saved/sync-pending state after save.
+- [ ] Confirm the saved Watch recording appears in iPhone History after iCloud sync.
+- [ ] Confirm the iPhone History row and detail screen identify the recording as Apple Watch sourced.
+- [ ] Confirm synced Watch route points draw correctly on iPhone and summary distance/duration are preserved.
+- [ ] Confirm a local route thumbnail is generated or regenerated on iPhone for the synced Watch recording.
+- [ ] Confirm the synced Watch recording does not imply a video file exists.
+- [ ] Add external-camera timing metadata to a synced Watch recording on iPhone.
+- [ ] Export GPX for the synced Watch recording and confirm it includes recording source, route timing, and external-camera timing metadata.
+- [ ] Record any sync delay, entitlement, iCloud account, or permission findings in the release notes for issue #71.
+
 ### Automated Coverage Gate
 
 - [ ] Confirm Swift Testing covers permission policy, permission recovery after Settings changes, Always authorization upgrade requests, concurrent recording prevention, GPS/video scene transition policy, video stop outcomes through the coordinator flow, local video storage semantics, Photos export/legacy fallback semantics, checkpoint recovery, large-route persistence, iCloud configuration, sync status messaging, and local-only video presentation.
@@ -132,8 +158,12 @@ Run these on a physical iPhone before submission:
 - [ ] Document Apple framework behavior separately: Photos may use iCloud Photos for copies the user saves or older Photos-backed videos.
 - [ ] Document Apple framework behavior separately: MapKit may load map imagery for route thumbnails and reverse geocode a saved route point to suggest editable titles and descriptions.
 - [ ] Confirm the app describes background GPS recording as optional and user-enabled.
-- [ ] Confirm App Store copy says ASMR Walk 1.1.0 is iPhone-only.
+- [ ] Confirm App Store copy says the iPhone app excludes iPad support in version 1.1.0.
+- [ ] Confirm App Store copy says version 1.1.0 includes a GPS-only Apple Watch companion app.
 - [ ] Include review notes that background location is GPS Walk only, requires the user to enable Background GPS Recording in Settings, and requires Always location permission.
+- [ ] Include review notes that the Apple Watch app records GPS-only walks, does not record video, and does not create HealthKit workouts.
+- [ ] Include review notes that Watch recordings sync through the user's private iCloud database and appear in iPhone History after sync.
+- [ ] Include review notes that external-camera fields are timing notes for user-managed footage and ASMR Walk does not import or sync those external video files.
 - [ ] Include screenshots for History, Walk, Video Walk, Recording Detail, and Settings.
 - [ ] Mention that route data is stored locally.
 - [ ] Mention that route data and recording metadata can sync through iCloud.
@@ -148,10 +178,11 @@ Run these on a physical iPhone before submission:
 ## Known Version 1.1.0 Scope
 
 - No iPad support.
-- No Apple Watch support.
+- Apple Watch support is GPS-only route recording.
 - No HealthKit workout integration.
 - Background route recording is GPS-only and opt-in.
 - No background Video Walk recording.
 - No burned-in video map overlay export.
 - No delete-from-Photos management for video copies saved to the user's Photos library.
 - iCloud sync covers recording metadata and routes, not full video files.
+- Simulator Watch-to-iPhone sync is non-authoritative for release; physical-device/TestFlight validation is tracked in GitHub issue #93.


### PR DESCRIPTION
## Summary

- Updates README, App Store copy, privacy policy, and release checklist for the Version 1.1.0 Apple Watch companion scope.
- Documents Watch recordings as GPS-only, iCloud-synced route metadata/points, with no Watch video or HealthKit workout support.
- Adds the physical Watch/iPhone sync validation gate through #93 before App Store submission.
- Adds release journal notes for the Watch documentation pass and simulator sync limitation.

## Beta Tester Notes

- Apple Watch recording is GPS-only in 1.1.0.
- Watch recordings should appear in iPhone History after private iCloud/CloudKit sync.
- Watch-to-iPhone sync was not reliable in Simulator, so physical-device/TestFlight validation is tracked separately in #93 before App Store submission.
- External-camera timing fields are metadata only; ASMR Walk does not import, store, or sync separately recorded camera footage.

## Testing

- Documentation-only change.
- Ran .

Closes #71
