### PR TITLE
Improve Photos video export flow

### DIFF
--- a/ASMR Walk/Features/History/HistoryView.swift
+++ b/ASMR Walk/Features/History/HistoryView.swift
@@ -166,6 +166,12 @@ private struct RecordingRow: View {
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+                if recording.hasVideo {
+                    Label(recording.photosExportAvailability.summaryTitle, systemImage: recording.photosExportAvailability.systemImage)
+                        .font(.caption)
+                        .foregroundStyle(recording.photosExportAvailability.isActionable ? .blue : .secondary)
+                }
             }
         }
         .padding(.vertical, 4)

--- a/ASMR Walk/Features/History/RecordingDetailView.swift
+++ b/ASMR Walk/Features/History/RecordingDetailView.swift
@@ -79,9 +79,7 @@ struct RecordingDetailView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(.red.opacity(0.1), in: .rect(cornerRadius: 16))
 
-                    if recording.localVideoFileExists {
-                        saveVideoToPhotosButton
-                    }
+                    photosExportCard
 
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Route Review")
@@ -103,7 +101,14 @@ struct RecordingDetailView: View {
         .sheet(isPresented: $isShowingExternalCameraEditor) {
             ExternalCameraTimingEditView(recording: recording)
         }
-        .alert("Video Export", isPresented: isShowingPhotoSaveStatus) {
+        .alert(photoSaveStatus?.title ?? "Video Export", isPresented: isShowingPhotoSaveStatus) {
+            if photoSaveStatus?.canOpenSettings == true {
+                Button("Open Settings") {
+                    photoSaveStatus = nil
+                    openAppSettings()
+                }
+            }
+
             Button("OK", role: .cancel) {
                 photoSaveStatus = nil
             }
@@ -240,16 +245,34 @@ struct RecordingDetailView: View {
         }
     }
 
+    private var photosExportCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(recording.photosExportAvailability.title, systemImage: recording.photosExportAvailability.systemImage)
+                .font(.headline)
+
+            Text(recording.photosExportAvailability.message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if recording.photosExportAvailability.isActionable {
+                saveVideoToPhotosButton
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary, in: .rect(cornerRadius: 16))
+    }
+
     private var saveVideoToPhotosButton: some View {
         Button {
             saveVideoToPhotos()
         } label: {
-            Label(saveVideoToPhotosTitle, systemImage: recording.videoAssetIdentifier == nil ? "photo.badge.plus" : "checkmark.circle")
+            Label(saveVideoToPhotosTitle, systemImage: recording.photosExportAvailability.systemImage)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(.borderedProminent)
         .tint(.red)
-        .disabled(isSavingVideoToPhotos || recording.videoAssetIdentifier != nil)
+        .disabled(isSavingVideoToPhotos || recording.photosExportAvailability.isActionable == false)
         .accessibilityIdentifier(AccessibilityID.saveVideoToPhotosButton)
     }
 
@@ -258,16 +281,12 @@ struct RecordingDetailView: View {
             return "Saving Video to Photos"
         }
 
-        if recording.videoAssetIdentifier != nil {
-            return "Video Saved to Photos"
-        }
-
-        return "Save Video to Photos"
+        return recording.photosExportAvailability.title
     }
 
     private func saveVideoToPhotos() {
-        guard let videoURL = recording.videoURL, FileManager.default.fileExists(atPath: videoURL.path) else {
-            photoSaveStatus = .failure("The local video file could not be found.")
+        guard let videoURL = recording.photosExportAvailability.fileURL else {
+            photoSaveStatus = .failure(recording.photosExportAvailability.message)
             return
         }
 
@@ -279,24 +298,59 @@ struct RecordingDetailView: View {
                 try modelContext.save()
                 photoSaveStatus = .success
             } catch {
-                photoSaveStatus = .failure(error.localizedDescription)
+                if let storeError = error as? PhotoLibraryVideoStore.StoreError,
+                   storeError == .accessDenied {
+                    photoSaveStatus = .permissionDenied(storeError.localizedDescription)
+                } else {
+                    photoSaveStatus = .failure(error.localizedDescription)
+                }
             }
             isSavingVideoToPhotos = false
         }
+    }
+
+    private func openAppSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        UIApplication.shared.open(settingsURL)
     }
 }
 
 private enum PhotoSaveStatus: Equatable {
     case success
+    case permissionDenied(String)
     case failure(String)
+
+    var title: String {
+        switch self {
+        case .success:
+            "Video Saved"
+        case .permissionDenied:
+            "Photos Access Needed"
+        case .failure:
+            "Video Export Failed"
+        }
+    }
 
     var message: String {
         switch self {
         case .success:
             "A copy of this video walk was saved to Photos. ASMR Walk will continue playing the local copy."
+        case let .permissionDenied(message):
+            "\(message) Enable Photos access in Settings to save a copy later."
         case let .failure(message):
             message
         }
+    }
+
+    var canOpenSettings: Bool {
+        if case .permissionDenied = self {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/ASMR Walk/Features/Video/PhotoLibraryVideoStore.swift
+++ b/ASMR Walk/Features/Video/PhotoLibraryVideoStore.swift
@@ -11,7 +11,7 @@ enum PhotoLibraryVideoStore {
     static let saveAccessExplanation = "ASMR Walk saves a copy of this video walk to Photos when you choose Save Video to Photos."
     static let legacyReadAccessExplanation = "ASMR Walk reads older Photos-backed video walks so you can replay them with your route."
 
-    enum StoreError: LocalizedError {
+    enum StoreError: LocalizedError, Equatable {
         case missingAddUsageDescription
         case missingReadUsageDescription
         case accessDenied

--- a/ASMR Walk/Models/WalkRecording+Presentation.swift
+++ b/ASMR Walk/Models/WalkRecording+Presentation.swift
@@ -161,6 +161,102 @@ extension WalkRecording {
 
         return "The route and recording details can sync through iCloud, but the video file stays on the device where it was recorded."
     }
+
+    var photosExportAvailability: PhotosVideoExportAvailability {
+        guard hasVideo else {
+            return .unavailable(reason: "This route-only recording has no video to save to Photos.")
+        }
+
+        if videoAssetIdentifier != nil {
+            return .saved
+        }
+
+        if let videoURL, localVideoFileExists {
+            return .available(source: .localVideo(fileURL: videoURL))
+        }
+
+        return .unavailable(reason: "The video file is not on this device, so it cannot be saved to Photos here.")
+    }
+}
+
+enum PhotosVideoExportSource: Equatable {
+    case localVideo(fileURL: URL)
+
+    var title: String {
+        switch self {
+        case .localVideo:
+            "In-App Video"
+        }
+    }
+}
+
+enum PhotosVideoExportAvailability: Equatable {
+    case available(source: PhotosVideoExportSource)
+    case saved
+    case unavailable(reason: String)
+
+    var title: String {
+        switch self {
+        case let .available(source):
+            "Save \(source.title) to Photos"
+        case .saved:
+            "Video Saved to Photos"
+        case .unavailable:
+            "Photos Export Unavailable"
+        }
+    }
+
+    var summaryTitle: String {
+        switch self {
+        case .available:
+            "Photos Export Available"
+        case .saved:
+            "Video Saved to Photos"
+        case .unavailable:
+            "Photos Export Unavailable"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .available:
+            "A copy can be saved to Photos. ASMR Walk keeps using the local in-app video for playback."
+        case .saved:
+            "A copy has already been saved to Photos. The in-app video remains available for playback."
+        case let .unavailable(reason):
+            reason
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .available:
+            "photo.badge.plus"
+        case .saved:
+            "checkmark.circle"
+        case .unavailable:
+            "photo.badge.exclamationmark"
+        }
+    }
+
+    var isActionable: Bool {
+        if case .available = self {
+            return true
+        }
+
+        return false
+    }
+
+    var fileURL: URL? {
+        guard case let .available(source) = self else {
+            return nil
+        }
+
+        switch source {
+        case let .localVideo(fileURL):
+            return fileURL
+        }
+    }
 }
 
 extension TimeInterval {

--- a/ASMR WalkTests/WalkRecordingModelTests.swift
+++ b/ASMR WalkTests/WalkRecordingModelTests.swift
@@ -36,6 +36,47 @@ struct WalkRecordingModelTests {
         #expect(recording.videoStorage == .localOnly)
         #expect(recording.videoAvailabilityTitle == "Video Not on This Device")
         #expect(recording.videoAvailabilityMessage.contains("video file stays on the device where it was recorded"))
+        #expect(recording.photosExportAvailability.title == "Photos Export Unavailable")
+        #expect(recording.photosExportAvailability.message.contains("not on this device"))
+    }
+
+    @Test("Photos export availability distinguishes saved and route-only recordings")
+    func photosExportAvailabilityStates() {
+        let routeOnlyRecording = WalkRecording(title: "Walk", mode: .walk)
+        let savedPhotosRecording = WalkRecording(
+            title: "Video Walk",
+            mode: .videoWalk,
+            videoAssetIdentifier: "photos-asset-id"
+        )
+
+        #expect(routeOnlyRecording.photosExportAvailability.title == "Photos Export Unavailable")
+        #expect(routeOnlyRecording.photosExportAvailability.summaryTitle == "Photos Export Unavailable")
+        #expect(routeOnlyRecording.photosExportAvailability.message.contains("no video"))
+        #expect(routeOnlyRecording.photosExportAvailability.isActionable == false)
+        #expect(savedPhotosRecording.photosExportAvailability.title == "Video Saved to Photos")
+        #expect(savedPhotosRecording.photosExportAvailability.summaryTitle == "Video Saved to Photos")
+        #expect(savedPhotosRecording.photosExportAvailability.isActionable == false)
+    }
+
+    @Test("Photos export is actionable for an in-app video file")
+    func photosExportAvailabilityForLocalVideoFile() throws {
+        let videoURL = FileManager.default.temporaryDirectory
+            .appending(path: "ASMRWalk-\(UUID().uuidString).mov")
+        FileManager.default.createFile(atPath: videoURL.path, contents: Data("video".utf8))
+        defer {
+            try? FileManager.default.removeItem(at: videoURL)
+        }
+
+        let recording = WalkRecording(
+            title: "Video Walk",
+            mode: .videoWalk,
+            videoURL: videoURL
+        )
+
+        #expect(recording.photosExportAvailability.title == "Save In-App Video to Photos")
+        #expect(recording.photosExportAvailability.summaryTitle == "Photos Export Available")
+        #expect(recording.photosExportAvailability.fileURL == videoURL)
+        #expect(recording.photosExportAvailability.isActionable)
     }
 
     @Test("Missing local thumbnails are detectable after sync")

--- a/Journal.md
+++ b/Journal.md
@@ -423,6 +423,12 @@ Issue 71 is the point where the Watch work stops being a stack of merged feature
 
 The simulator taught one more release lesson: some workflows can compile, unit test, and still need real hardware before they are release facts. Watch-to-iPhone CloudKit sync was not reliable in Simulator, so the checklist treats physical Watch/iPhone validation as an App Store submission gate instead of pretending the simulator run settled it. Think of issue #93 as the final trail marker at the parking lot: #71 can prepare the map, but the release should not leave without checking that marker off.
 
+### Photos Export Gets a Door Sign
+
+Issue 39 takes the "Save Video to Photos" path from a useful button to a clearer little contract. A video row now says whether Photos export is available, already done, or unavailable because the file is not on this device. The detail screen shows the same state before the user taps anything, which matters because synced metadata can travel farther than the local `.mov`.
+
+The export itself still copies a local file into Photos and keeps ASMR Walk's in-app playback source unchanged. That is the important ownership rule: Photos gets a copy, not the only copy. Permission denial also has a proper recovery path now, so a blocked Photos request points the user to Settings instead of sounding like the video disappeared.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary

- Adds a presentation model for Photos video export availability: available, already saved, or unavailable.
- Shows Photos export state in History rows and Recording Detail for video recordings.
- Keeps the save action on the detail screen for local in-app video files and leaves synced/missing local videos clearly unavailable.
- Adds a Photos permission-denied recovery path with an Open Settings action.
- Adds model tests for route-only, already-saved, missing-local, and local-video export availability.

## Notes

Issue #9 is still the future burned-in overlay export work. The Photos store continues to save any local video file URL, so #9 can hand its rendered output to this same path when that exporter exists.

## Testing

- Xcode live diagnostics: no issues in changed Swift files.
- Xcode MCP BuildProject: passed.
- : passed.
- Targeted simulator test command did not run because CoreSimulatorService could not enumerate the iPhone 17 Pro simulator in this session.

Closes #39
