### PR TITLE
Define .asmrroute package contract

### DIFF
--- a/ASMR Walk/Features/History/ASMRRoutePackage.swift
+++ b/ASMR Walk/Features/History/ASMRRoutePackage.swift
@@ -1,0 +1,264 @@
+//
+//  ASMRRoutePackage.swift
+//  ASMR Walk
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+struct ASMRRoutePackage: Equatable, Sendable {
+    static let schemaVersion = 1
+    static let fileExtension = "asmrroute"
+    static let manifestFilename = "manifest.json"
+    static let routePointsFilename = "route-points.json"
+    static let sourceGPXFilename = "source.gpx"
+
+    let manifest: Manifest
+    let routePoints: [RoutePoint]
+    let sourceGPX: String?
+
+    init(
+        manifest: Manifest,
+        routePoints: [RoutePoint],
+        sourceGPX: String? = nil
+    ) {
+        self.manifest = manifest
+        self.routePoints = routePoints.sorted { $0.timestamp < $1.timestamp }
+        self.sourceGPX = sourceGPX
+    }
+
+    init(
+        export: WalkRouteExport,
+        sourceGPX: String? = nil,
+        videoReferences: [VideoReference] = []
+    ) {
+        let points = export.points.map { point in
+            RoutePoint(
+                timestamp: point.timestamp,
+                latitude: point.latitude,
+                longitude: point.longitude,
+                altitude: point.altitude,
+                horizontalAccuracy: point.horizontalAccuracy,
+                speed: point.speed
+            )
+        }
+        let resolvedVideoReferences: [VideoReference]
+        if videoReferences.isEmpty, export.hasVideo {
+            resolvedVideoReferences = [
+                VideoReference(
+                    kind: .localVideo,
+                    displayName: "In-app video on source device",
+                    sourceIdentifier: nil,
+                    startsAt: nil,
+                    offsetSeconds: nil,
+                    isEmbedded: false
+                )
+            ]
+        } else {
+            resolvedVideoReferences = videoReferences
+        }
+
+        let externalVideoReference: VideoReference? = if let reference = export.externalVideoReference,
+                                                         reference.isEmpty == false {
+            VideoReference(
+                kind: .externalCamera,
+                displayName: reference,
+                sourceIdentifier: reference,
+                startsAt: export.externalVideoStartedAt,
+                offsetSeconds: export.externalVideoStartedAt?.timeIntervalSince(export.routeStartedAt),
+                isEmbedded: false
+            )
+        } else {
+            nil
+        }
+
+        manifest = Manifest(
+            packageIdentifier: export.recordingID,
+            title: export.title,
+            walkDescription: export.walkDescription.isEmpty ? nil : export.walkDescription,
+            createdAt: export.createdAt,
+            durationSeconds: export.duration,
+            distanceMeters: export.distanceMeters,
+            mode: export.mode,
+            recordingSource: export.recordingSource,
+            captureDeviceName: export.captureDeviceName,
+            routeStartedAt: export.routeStartedAt,
+            routeEndedAt: export.routeEndedAt,
+            routePointCount: points.count,
+            routePointsFile: Self.routePointsFilename,
+            sourceGPXFile: sourceGPX == nil ? nil : Self.sourceGPXFilename,
+            videoReferences: externalVideoReference.map { resolvedVideoReferences + [$0] } ?? resolvedVideoReferences
+        )
+        routePoints = points.sorted { $0.timestamp < $1.timestamp }
+        self.sourceGPX = sourceGPX
+    }
+
+    func write(to packageURL: URL, fileManager: FileManager = .default) throws {
+        if fileManager.fileExists(atPath: packageURL.path) {
+            try fileManager.removeItem(at: packageURL)
+        }
+
+        try fileManager.createDirectory(at: packageURL, withIntermediateDirectories: true)
+        try Self.encode(manifest).write(
+            to: packageURL.appending(path: Self.manifestFilename),
+            options: .atomic
+        )
+        try Self.encode(routePoints).write(
+            to: packageURL.appending(path: manifest.routePointsFile),
+            options: .atomic
+        )
+
+        if let sourceGPX, let sourceGPXFile = manifest.sourceGPXFile {
+            try Data(sourceGPX.utf8).write(
+                to: packageURL.appending(path: sourceGPXFile),
+                options: .atomic
+            )
+        }
+    }
+
+    static func load(from packageURL: URL) throws -> ASMRRoutePackage {
+        let manifest = try decode(
+            Manifest.self,
+            from: Data(contentsOf: packageURL.appending(path: manifestFilename))
+        )
+        guard manifest.schemaVersion == schemaVersion else {
+            throw PackageError.unsupportedSchemaVersion(manifest.schemaVersion)
+        }
+
+        let routePoints = try decode(
+            [RoutePoint].self,
+            from: Data(contentsOf: packageURL.appending(path: manifest.routePointsFile))
+        )
+        let sourceGPX: String?
+        if let sourceGPXFile = manifest.sourceGPXFile {
+            sourceGPX = try String(
+                decoding: Data(contentsOf: packageURL.appending(path: sourceGPXFile)),
+                as: UTF8.self
+            )
+        } else {
+            sourceGPX = nil
+        }
+
+        guard routePoints.count == manifest.routePointCount else {
+            throw PackageError.routePointCountMismatch(
+                expected: manifest.routePointCount,
+                actual: routePoints.count
+            )
+        }
+
+        return ASMRRoutePackage(
+            manifest: manifest,
+            routePoints: routePoints,
+            sourceGPX: sourceGPX
+        )
+    }
+
+    static func packageURL(forTitle title: String, in directory: URL) -> URL {
+        directory.appending(path: "\(filenameBase(for: title)).\(fileExtension)", directoryHint: .isDirectory)
+    }
+
+    private static func filenameBase(for title: String) -> String {
+        let baseName = title
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.isEmpty == false }
+            .joined(separator: "-")
+
+        return baseName.isEmpty ? "ASMR-Walk" : baseName
+    }
+
+    private static func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(value)
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: data)
+    }
+}
+
+extension ASMRRoutePackage {
+    struct Manifest: Codable, Equatable, Sendable {
+        var schemaVersion = ASMRRoutePackage.schemaVersion
+        var packageIdentifier: UUID
+        var title: String
+        var walkDescription: String?
+        var createdAt: Date
+        var durationSeconds: TimeInterval
+        var distanceMeters: Double?
+        var mode: RecordingMode
+        var recordingSource: WalkRecordingSource
+        var captureDeviceName: String?
+        var routeStartedAt: Date
+        var routeEndedAt: Date
+        var routePointCount: Int
+        var routePointsFile = ASMRRoutePackage.routePointsFilename
+        var sourceGPXFile: String?
+        var videoReferences: [VideoReference]
+        var createdBy = "ASMR Walk"
+    }
+
+    struct RoutePoint: Codable, Equatable, Sendable {
+        let timestamp: Date
+        let latitude: Double
+        let longitude: Double
+        let altitude: Double?
+        let horizontalAccuracy: Double
+        let speed: Double?
+
+        init(
+            timestamp: Date,
+            latitude: Double,
+            longitude: Double,
+            altitude: Double?,
+            horizontalAccuracy: Double,
+            speed: Double?
+        ) {
+            self.timestamp = timestamp
+            self.latitude = latitude
+            self.longitude = longitude
+            self.altitude = altitude
+            self.horizontalAccuracy = horizontalAccuracy
+            self.speed = speed
+        }
+
+    }
+
+    struct VideoReference: Codable, Equatable, Sendable {
+        enum Kind: String, Codable, Sendable {
+            case localVideo
+            case photosAsset
+            case externalCamera
+        }
+
+        let kind: Kind
+        let displayName: String
+        let sourceIdentifier: String?
+        let startsAt: Date?
+        let offsetSeconds: TimeInterval?
+        let isEmbedded: Bool
+    }
+
+    enum PackageError: LocalizedError, Equatable {
+        case unsupportedSchemaVersion(Int)
+        case routePointCountMismatch(expected: Int, actual: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unsupportedSchemaVersion(version):
+                "Unsupported .asmrroute schema version \(version)."
+            case let .routePointCountMismatch(expected, actual):
+                "The .asmrroute package expected \(expected) route points but found \(actual)."
+            }
+        }
+    }
+}
+
+extension UTType {
+    static var asmrRoutePackage: UTType {
+        UTType(filenameExtension: ASMRRoutePackage.fileExtension) ?? .package
+    }
+}

--- a/ASMR Walk/Features/History/WalkRouteExport.swift
+++ b/ASMR Walk/Features/History/WalkRouteExport.swift
@@ -22,6 +22,7 @@ struct WalkRouteExport {
     let walkDescription: String
     let createdAt: Date
     let duration: TimeInterval
+    let distanceMeters: Double
     let mode: RecordingMode
     let hasVideo: Bool
     let recordingSource: WalkRecordingSource
@@ -39,6 +40,7 @@ struct WalkRouteExport {
         walkDescription = recording.walkDescription
         createdAt = recording.createdAt
         duration = recording.duration
+        distanceMeters = recording.distanceMeters
         mode = recording.mode
         hasVideo = recording.hasVideo
         recordingSource = recording.source

--- a/ASMR WalkTests/ASMRRoutePackageTests.swift
+++ b/ASMR WalkTests/ASMRRoutePackageTests.swift
@@ -1,0 +1,129 @@
+//
+//  ASMRRoutePackageTests.swift
+//  ASMR WalkTests
+//
+
+import Foundation
+import Testing
+@testable import ASMR_Walk
+
+@MainActor
+struct ASMRRoutePackageTests {
+    @Test(".asmrroute packages round-trip manifest, route points, and source GPX")
+    func packageRoundTrip() throws {
+        let recordingID = try #require(UUID(uuidString: "C9D171A2-B9E4-45A7-8BE8-D6120F9761C7"))
+        let routeStartedAt = Date(timeIntervalSince1970: 1_000)
+        let recording = WalkRecording(
+            id: recordingID,
+            title: "Package Walk",
+            createdAt: routeStartedAt,
+            duration: 120,
+            distanceMeters: 345.5,
+            mode: .walk,
+            recordingSource: .appleWatch,
+            captureDeviceName: "Apple Watch",
+            routeStartedAt: routeStartedAt,
+            routeEndedAt: routeStartedAt.addingTimeInterval(120),
+            externalVideoReference: "A-cam clip",
+            externalVideoStartedAt: routeStartedAt.addingTimeInterval(-3),
+            points: [
+                makePoint(timestamp: 1_020, latitude: 33.4490, longitude: -112.0728),
+                makePoint(timestamp: 1_000, latitude: 33.4484, longitude: -112.0740, altitude: 331.25)
+            ]
+        )
+        let export = WalkRouteExport(recording: recording)
+        let package = ASMRRoutePackage(export: export, sourceGPX: export.gpxText)
+        let packageURL = ASMRRoutePackage.packageURL(
+            forTitle: recording.title,
+            in: FileManager.default.temporaryDirectory
+        )
+        defer {
+            try? FileManager.default.removeItem(at: packageURL)
+        }
+
+        try package.write(to: packageURL)
+        let loaded = try ASMRRoutePackage.load(from: packageURL)
+
+        #expect(loaded == package)
+        #expect(loaded.manifest.schemaVersion == 1)
+        #expect(loaded.manifest.packageIdentifier == recordingID)
+        #expect(loaded.manifest.recordingSource == .appleWatch)
+        #expect(loaded.manifest.distanceMeters == 345.5)
+        #expect(loaded.manifest.routePointCount == 2)
+        #expect(loaded.routePoints.map(\.timestamp) == [
+            Date(timeIntervalSince1970: 1_000),
+            Date(timeIntervalSince1970: 1_020)
+        ])
+        #expect(loaded.sourceGPX?.contains("<gpx version=\"1.1\"") == true)
+        #expect(loaded.manifest.videoReferences.contains {
+            $0.kind == .externalCamera && $0.offsetSeconds == -3
+        })
+    }
+
+    @Test(".asmrroute manifest can represent non-embedded Photos video references")
+    func packageManifestRepresentsPhotosVideoReferences() throws {
+        let recording = WalkRecording(
+            title: "Video Package",
+            createdAt: Date(timeIntervalSince1970: 2_000),
+            duration: 30,
+            mode: .videoWalk,
+            videoAssetIdentifier: "photos-local-id",
+            points: [
+                makePoint(timestamp: 2_000),
+                makePoint(timestamp: 2_010)
+            ]
+        )
+        let photosReference = ASMRRoutePackage.VideoReference(
+            kind: .photosAsset,
+            displayName: "Photos video selected on Mac",
+            sourceIdentifier: "photos-local-id",
+            startsAt: Date(timeIntervalSince1970: 2_000),
+            offsetSeconds: 0,
+            isEmbedded: false
+        )
+
+        let package = ASMRRoutePackage(
+            export: WalkRouteExport(recording: recording),
+            videoReferences: [photosReference]
+        )
+
+        #expect(package.manifest.videoReferences == [photosReference])
+        #expect(package.manifest.videoReferences.first?.isEmbedded == false)
+        #expect(package.manifest.routePointsFile == ASMRRoutePackage.routePointsFilename)
+        #expect(package.manifest.sourceGPXFile == nil)
+    }
+
+    @Test(".asmrroute loader rejects unsupported schema versions")
+    func unsupportedSchemaVersionFailsLoad() throws {
+        var manifest = ASMRRoutePackage.Manifest(
+            packageIdentifier: UUID(),
+            title: "Future Package",
+            createdAt: Date(timeIntervalSince1970: 1),
+            durationSeconds: 10,
+            distanceMeters: 20,
+            mode: .walk,
+            recordingSource: .iPhone,
+            captureDeviceName: nil,
+            routeStartedAt: Date(timeIntervalSince1970: 1),
+            routeEndedAt: Date(timeIntervalSince1970: 11),
+            routePointCount: 0,
+            sourceGPXFile: nil,
+            videoReferences: []
+        )
+        manifest.schemaVersion = 999
+        let package = ASMRRoutePackage(manifest: manifest, routePoints: [])
+        let packageURL = ASMRRoutePackage.packageURL(
+            forTitle: "Future Package",
+            in: FileManager.default.temporaryDirectory
+        )
+        defer {
+            try? FileManager.default.removeItem(at: packageURL)
+        }
+
+        try package.write(to: packageURL)
+
+        #expect(throws: ASMRRoutePackage.PackageError.unsupportedSchemaVersion(999)) {
+            try ASMRRoutePackage.load(from: packageURL)
+        }
+    }
+}

--- a/ASMR_ROUTE_PACKAGE.md
+++ b/ASMR_ROUTE_PACKAGE.md
@@ -1,0 +1,79 @@
+# ASMR Route Package
+
+`.asmrroute` is the ASMR Walk handoff package for the Mac importer and the future Final Cut Pro/Motion renderer. It is a directory package with deterministic JSON metadata and route data. The renderer should be able to load it without reaching back into iCloud, Photos, or an iPhone sandbox during timeline playback or export.
+
+## Version 1 Layout
+
+```text
+Example Walk.asmrroute/
+  manifest.json
+  route-points.json
+  source.gpx        optional
+```
+
+## `manifest.json`
+
+The manifest is UTF-8 JSON encoded with stable sorted keys.
+
+Required fields:
+
+- `schemaVersion`: currently `1`.
+- `packageIdentifier`: UUID, normally the ASMR Walk recording ID.
+- `title`: display title.
+- `createdAt`: ISO-8601 package/recording date.
+- `durationSeconds`: recording duration.
+- `mode`: ASMR Walk recording mode, such as `walk` or `videoWalk`.
+- `recordingSource`: route source, such as `iPhone` or `appleWatch`.
+- `routeStartedAt` and `routeEndedAt`: ISO-8601 timing anchors.
+- `routePointCount`: expected number of points in `route-points.json`.
+- `routePointsFile`: currently `route-points.json`.
+- `videoReferences`: an array of non-embedded video references.
+- `createdBy`: currently `ASMR Walk`.
+
+Optional fields:
+
+- `walkDescription`
+- `distanceMeters`
+- `captureDeviceName`
+- `sourceGPXFile`
+
+## `route-points.json`
+
+Route points are stored in timestamp order. Each point can include:
+
+- `timestamp`
+- `latitude`
+- `longitude`
+- `altitude`
+- `horizontalAccuracy`
+- `speed`
+
+## `source.gpx`
+
+When a package is created from an explicit GPX import or export, the source GPX should be preserved as `source.gpx`. Package consumers should treat `manifest.json` and `route-points.json` as the normalized contract and `source.gpx` as provenance.
+
+## Video References
+
+Video files are not embedded by default. A video reference can represent:
+
+- `localVideo`: an ASMR Walk in-app video on the source device. Do not store iPhone sandbox paths as portable package references.
+- `photosAsset`: a user-selected Photos asset reference. Treat device-local Photos identifiers as hints, not globally portable IDs.
+- `externalCamera`: a user-managed external clip label plus optional timing data.
+
+Each video reference includes:
+
+- `kind`
+- `displayName`
+- `sourceIdentifier`
+- `startsAt`
+- `offsetSeconds`
+- `isEmbedded`
+
+For Version 1.1.0, `isEmbedded` should normally be `false`. A later importer may add explicit user-controlled media copying, but the first renderer contract should not depend on Photos, iCloud, or large video files being available inside the package.
+
+## Compatibility Rules
+
+- Consumers must reject unsupported `schemaVersion` values.
+- Consumers should verify that `routePointCount` matches the decoded route point file.
+- Route rendering should rely on normalized route points, not `source.gpx` parsing.
+- Missing video references must be shown as a recoverable state, not a package failure.

--- a/Journal.md
+++ b/Journal.md
@@ -429,6 +429,12 @@ Issue 39 takes the "Save Video to Photos" path from a useful button to a clearer
 
 The export itself still copies a local file into Photos and keeps ASMR Walk's in-app playback source unchanged. That is the important ownership rule: Photos gets a copy, not the only copy. Permission denial also has a proper recovery path now, so a blocked Photos request points the user to Settings instead of sounding like the video disappeared.
 
+### The Route Package Is a Lunchbox
+
+Issue 72 defines `.asmrroute`, the little package the Mac importer will hand to the future Final Cut Pro/Motion renderer. It carries a manifest, normalized route points, optional source GPX, and video references that say what kind of media belongs with the route without stuffing the media itself into the box by default.
+
+That separation is the whole point. The renderer should be able to draw deterministically from route data during timeline playback, not ask Photos, CloudKit, or an iPhone sandbox where the trail went. Big video files stay outside unless a future workflow explicitly decides to copy them in.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ iCloud library sync is not gated by a StoreKit subscription in this implementati
 - Route export through the iOS share sheet.
 - Google Maps walking-route URL export.
 - GPX file export for higher-fidelity route sharing, including recording descriptions when present.
+- `.asmrroute` package contract for future Mac importer and Final Cut Pro/Motion route overlay workflows.
 - Video files remain local to the device where they were recorded unless the user saves a copy to Photos.
 
 ## Tech Stack
@@ -141,6 +142,10 @@ The unit test suite covers:
 UI tests cover the main tab surfaces and launch behavior. Camera, microphone, outdoor GPS, and Watch-to-iPhone sync flows should be validated on physical devices after privacy keys and entitlements are configured.
 
 The app uses a native static launch screen configured through the target Info settings. It does not show an artificial SwiftUI splash screen after launch.
+
+## ASMR Route Packages
+
+The `.asmrroute` package format is documented in `ASMR_ROUTE_PACKAGE.md`. Version 1 packages contain a deterministic `manifest.json`, normalized `route-points.json`, and optional preserved `source.gpx`. They are designed as the stable handoff from ASMR Walk import workflows to future Final Cut Pro/Motion rendering without requiring the renderer to query iCloud, Photos, or an iPhone sandbox.
 
 ## Current Limitations
 


### PR DESCRIPTION
## Summary

- Adds `ASMRRoutePackage`, a deterministic `.asmrroute` directory package contract with `manifest.json`, `route-points.json`, and optional `source.gpx`.
- Carries route metadata, timing metadata, recording source, distance, source GPX provenance, and non-embedded video references for local, Photos, and external-camera workflows.
- Adds encode/decode validation, schema version rejection, route point count validation, and package filename helpers.
- Documents the Version 1 package layout in `ASMR_ROUTE_PACKAGE.md` and links it from the README.
- Adds Swift Testing coverage for package round-trip, Photos video references, and unsupported schema versions.

## Testing

- Xcode live diagnostics: clean for `ASMRRoutePackage.swift`, `WalkRouteExport.swift`, and `ASMRRoutePackageTests.swift`.
- Xcode MCP BuildProject: passed.
- `git diff --check`: passed.
- Targeted `xcodebuild test` and `build-for-testing` could not run because CoreSimulatorService could not enumerate simulator devices and shell access could not write required DerivedData metadata.

Closes #72
