### PR TITLE
Add Mac importer route map preview

### DIFF
--- a/ASMR Walk Mac Importer/MacImporterView.swift
+++ b/ASMR Walk Mac Importer/MacImporterView.swift
@@ -16,18 +16,24 @@ struct MacImporterView: View {
     @State private var isImportingGPX = false
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                header
-                cloudSyncPanel
-                syncedRecordingList
-                statusPanel
-                actionBar
+        HSplitView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    header
+                    cloudSyncPanel
+                    syncedRecordingList
+                    statusPanel
+                    actionBar
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(24)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(minWidth: 360, idealWidth: 430)
+
+            routePreviewPanel
+                .frame(minWidth: 460)
         }
-        .frame(width: 680, height: 620)
+        .frame(width: 980, height: 680)
         .fileImporter(
             isPresented: $isImportingGPX,
             allowedContentTypes: [.gpx, .xml],
@@ -86,12 +92,11 @@ struct MacImporterView: View {
             } else {
                 VStack(spacing: 0) {
                     ForEach(syncedRecordings) { recording in
-                        SyncedRecordingRow(recording: recording) {
-                            do {
-                                try viewModel.exportSyncedRecording(recording)
-                            } catch {
-                                viewModel.showFailure(error)
-                            }
+                        SyncedRecordingRow(
+                            recording: recording,
+                            isSelected: viewModel.routePreview?.id == recording.id
+                        ) {
+                            viewModel.loadSyncedRecording(recording)
                         }
 
                         if recording.id != syncedRecordings.last?.id {
@@ -102,6 +107,54 @@ struct MacImporterView: View {
                 .background(.regularMaterial, in: .rect(cornerRadius: 8))
             }
         }
+    }
+
+    private var routePreviewPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(viewModel.routePreview?.title ?? "Route Preview")
+                        .font(.title2.bold())
+                        .lineLimit(1)
+
+                    if let routePreview = viewModel.routePreview {
+                        Text(routePreview.sourceDescription)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    } else {
+                        Text("Load a GPX file or synced recording.")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                if let routePreview = viewModel.routePreview {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text("\(routePreview.routePointCount) pts")
+                            .font(.callout.monospacedDigit())
+                        Text(routePreview.durationText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            RoutePreviewMapView(route: viewModel.routePreview)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipShape(.rect(cornerRadius: 8))
+
+            if let routePreview = viewModel.routePreview {
+                HStack(spacing: 12) {
+                    Label(routePreview.distanceText, systemImage: "point.topleft.down.curvedto.point.bottomright.up")
+                    Label(routePreview.package.manifest.recordingSource.title, systemImage: "record.circle")
+                    Label(routePreview.package.manifest.mode.title, systemImage: routePreview.package.manifest.mode.systemImage)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(24)
     }
 
     private var statusPanel: some View {
@@ -136,6 +189,15 @@ struct MacImporterView: View {
             }
             .buttonStyle(.borderedProminent)
 
+            Button("Create Package", systemImage: "shippingbox") {
+                do {
+                    try viewModel.exportLoadedRoute()
+                } catch {
+                    viewModel.showFailure(error)
+                }
+            }
+            .disabled(viewModel.routePreview?.routePointCount ?? 0 == 0)
+
             Button("Reveal Package", systemImage: "arrow.up.forward.app") {
                 viewModel.revealPackageInFinder()
             }
@@ -165,7 +227,8 @@ struct MacImporterView: View {
 
 private struct SyncedRecordingRow: View {
     let recording: WalkRecording
-    let export: () -> Void
+    let isSelected: Bool
+    let preview: () -> Void
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -194,12 +257,13 @@ private struct SyncedRecordingRow: View {
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
 
-            Button("Create Package", systemImage: "shippingbox") {
-                export()
+            Button("Preview", systemImage: isSelected ? "checkmark.circle.fill" : "map") {
+                preview()
             }
             .disabled(recording.points.isEmpty)
         }
         .padding(12)
+        .background(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
     }
 }
 

--- a/ASMR Walk Mac Importer/MacImporterViewModel.swift
+++ b/ASMR Walk Mac Importer/MacImporterViewModel.swift
@@ -12,9 +12,10 @@ import UniformTypeIdentifiers
 @Observable
 final class MacImporterViewModel {
     private(set) var statusTitle = "Ready"
-    private(set) var statusMessage: String? = "Choose an ASMR Walk GPX export to create an .asmrroute package."
+    private(set) var statusMessage: String? = "Select a synced recording or import a GPX file to preview a route."
     private(set) var statusSystemImage = "point.topleft.down.curvedto.point.bottomright.up"
     private(set) var packageURL: URL?
+    private(set) var routePreview: RoutePreview?
 
     private let importer: ASMRGPXRouteImporter
     private let fileManager: FileManager
@@ -34,13 +35,13 @@ final class MacImporterViewModel {
                 return
             }
 
-            try importGPX(from: selectedURL)
+            try loadGPX(from: selectedURL)
         } catch {
             showFailure(error)
         }
     }
 
-    func importGPX(from gpxURL: URL) throws {
+    func loadGPX(from gpxURL: URL) throws {
         guard gpxURL.startAccessingSecurityScopedResource() else {
             throw ImportError.fileAccessDenied
         }
@@ -53,12 +54,34 @@ final class MacImporterViewModel {
             fromGPXData: data,
             sourceFilename: gpxURL.lastPathComponent
         )
+        loadRoutePreview(
+            package,
+            sourceDescription: "GPX file: \(gpxURL.lastPathComponent)"
+        )
+    }
+
+    func loadSyncedRecording(_ recording: WalkRecording) {
+        let package = ASMRRoutePackage(recording: recording)
+        loadRoutePreview(
+            package,
+            sourceDescription: "Synced \(recording.source.title) recording"
+        )
+    }
+
+    func exportLoadedRoute() throws {
+        guard let package = routePreview?.package else {
+            throw ImportError.noRouteLoaded
+        }
+
         try writePackage(package, successMessage: "\(package.manifest.routePointCount) route points were written to %@.")
     }
 
-    func exportSyncedRecording(_ recording: WalkRecording) throws {
-        let package = ASMRRoutePackage(recording: recording)
-        try writePackage(package, successMessage: "\(package.manifest.routePointCount) synced route points were written to %@.")
+    private func loadRoutePreview(_ package: ASMRRoutePackage, sourceDescription: String) {
+        routePreview = RoutePreview(package: package, sourceDescription: sourceDescription)
+        packageURL = nil
+        statusTitle = "Route Loaded"
+        statusMessage = "\(package.manifest.routePointCount) route points are ready to preview."
+        statusSystemImage = "map.fill"
     }
 
     private func writePackage(_ package: ASMRRoutePackage, successMessage: String) throws {
@@ -119,6 +142,7 @@ extension MacImporterViewModel {
         case fileAccessDenied
         case outputDirectoryAccessDenied
         case outputDirectoryNotSelected
+        case noRouteLoaded
 
         var errorDescription: String? {
             switch self {
@@ -128,6 +152,8 @@ extension MacImporterViewModel {
                 "The selected output folder could not be accessed."
             case .outputDirectoryNotSelected:
                 "No output folder was selected."
+            case .noRouteLoaded:
+                "Load a route before creating an .asmrroute package."
             }
         }
     }

--- a/ASMR Walk Mac Importer/RoutePreview.swift
+++ b/ASMR Walk Mac Importer/RoutePreview.swift
@@ -1,0 +1,52 @@
+//
+//  RoutePreview.swift
+//  ASMR Walk Mac Importer
+//
+
+import Foundation
+
+struct RoutePreview: Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let sourceDescription: String
+    let package: ASMRRoutePackage
+
+    init(package: ASMRRoutePackage, sourceDescription: String) {
+        self.id = package.manifest.packageIdentifier
+        self.title = package.manifest.title
+        self.sourceDescription = sourceDescription
+        self.package = package
+    }
+
+    var routePointCount: Int {
+        package.routePoints.count
+    }
+
+    var durationText: String {
+        Self.durationFormatter.string(from: package.manifest.durationSeconds) ?? "0:00"
+    }
+
+    var distanceText: String {
+        guard let distanceMeters = package.manifest.distanceMeters else {
+            return "Distance unavailable"
+        }
+
+        let measurement = Measurement(value: distanceMeters, unit: UnitLength.meters)
+        return Self.distanceFormatter.string(from: measurement)
+    }
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter
+    }()
+
+    private static let distanceFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.numberFormatter.maximumFractionDigits = 2
+        return formatter
+    }()
+}

--- a/ASMR Walk Mac Importer/RoutePreviewMapView.swift
+++ b/ASMR Walk Mac Importer/RoutePreviewMapView.swift
@@ -1,0 +1,94 @@
+//
+//  RoutePreviewMapView.swift
+//  ASMR Walk Mac Importer
+//
+
+import MapKit
+import SwiftUI
+
+struct RoutePreviewMapView: View {
+    let route: RoutePreview?
+
+    @State private var position = MapCameraPosition.automatic
+
+    var body: some View {
+        Group {
+            if let route {
+                Map(position: $position, interactionModes: [.pan, .zoom]) {
+                    if route.coordinates.count > 1 {
+                        MapPolyline(coordinates: route.coordinates)
+                            .stroke(.green, style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round))
+                    }
+
+                    if let start = route.coordinates.first {
+                        Marker("Start", systemImage: "figure.walk", coordinate: start)
+                            .tint(.green)
+                    }
+
+                    if route.coordinates.count > 1, let end = route.coordinates.last {
+                        Marker("Finish", systemImage: "flag.checkered", coordinate: end)
+                            .tint(.red)
+                    }
+                }
+                .mapStyle(.standard(elevation: .realistic))
+                .mapControls {
+                    MapCompass()
+                    MapScaleView()
+                    MapZoomStepper()
+                }
+                .onAppear {
+                    position = route.cameraPosition
+                }
+                .onChange(of: route.id) {
+                    position = route.cameraPosition
+                }
+                .accessibilityLabel("Map showing the loaded walking route")
+            } else {
+                ContentUnavailableView(
+                    "No Route Loaded",
+                    systemImage: "map",
+                    description: Text("Select a synced recording or import a GPX file to preview its route.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.quaternary)
+            }
+        }
+    }
+}
+
+private extension RoutePreview {
+    var coordinates: [CLLocationCoordinate2D] {
+        package.routePoints.map {
+            CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+        }
+    }
+
+    var cameraPosition: MapCameraPosition {
+        guard coordinates.isEmpty == false else {
+            return .automatic
+        }
+
+        return .rect(mapRect)
+    }
+
+    private var mapRect: MKMapRect {
+        let points = coordinates.map(MKMapPoint.init)
+        let routeRect = points.reduce(MKMapRect.null) { partialResult, point in
+            let pointRect = MKMapRect(x: point.x, y: point.y, width: 1, height: 1)
+            return partialResult.union(pointRect)
+        }
+
+        let minimumDimension: Double = 1_000
+        let width = max(routeRect.width * 1.25, minimumDimension)
+        let height = max(routeRect.height * 1.25, minimumDimension)
+        let insetX = (width - routeRect.width) / 2
+        let insetY = (height - routeRect.height) / 2
+
+        return MKMapRect(
+            x: routeRect.origin.x - insetX,
+            y: routeRect.origin.y - insetY,
+            width: width,
+            height: height
+        )
+    }
+}

--- a/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
+++ b/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
@@ -5,6 +5,7 @@
 //  Created by David Heath on 8/30/26.
 //
 
+import Foundation
 import Testing
 import SwiftData
 @testable import ASMR_Walk_Mac_Importer
@@ -85,6 +86,61 @@ struct ASMR_Walk_Mac_ImporterTests {
         #expect(package.manifest.sourceGPXFile == nil)
         #expect(package.sourceGPX == nil)
         #expect(package.routePoints.map(\.timestamp) == [start, start.addingTimeInterval(60)])
+    }
+
+    @Test func routePreviewSummarizesLoadedPackage() {
+        let start = Date(timeIntervalSince1970: 2_000)
+        let package = ASMRRoutePackage(
+            manifest: ASMRRoutePackage.Manifest(
+                packageIdentifier: UUID(uuidString: "48DB6037-9676-46F8-A272-E029A1E96F66")!,
+                title: "Preview Route",
+                walkDescription: nil,
+                createdAt: start,
+                durationSeconds: 90,
+                distanceMeters: 450,
+                mode: .walk,
+                recordingSource: .iPhone,
+                captureDeviceName: nil,
+                routeStartedAt: start,
+                routeEndedAt: start.addingTimeInterval(90),
+                routePointCount: 2,
+                sourceGPXFile: nil,
+                videoReferences: []
+            ),
+            routePoints: [
+                ASMRRoutePackage.RoutePoint(
+                    timestamp: start,
+                    latitude: 36.11,
+                    longitude: -86.66,
+                    altitude: nil,
+                    horizontalAccuracy: 5,
+                    speed: nil
+                ),
+                ASMRRoutePackage.RoutePoint(
+                    timestamp: start.addingTimeInterval(90),
+                    latitude: 36.12,
+                    longitude: -86.67,
+                    altitude: nil,
+                    horizontalAccuracy: 4,
+                    speed: nil
+                )
+            ]
+        )
+
+        let preview = RoutePreview(package: package, sourceDescription: "GPX file: Preview.gpx")
+
+        #expect(preview.id == package.manifest.packageIdentifier)
+        #expect(preview.title == "Preview Route")
+        #expect(preview.sourceDescription == "GPX file: Preview.gpx")
+        #expect(preview.routePointCount == 2)
+    }
+
+    @Test func exportWithoutLoadedRouteReportsFailure() {
+        let viewModel = MacImporterViewModel()
+
+        #expect(throws: MacImporterViewModel.ImportError.noRouteLoaded) {
+            try viewModel.exportLoadedRoute()
+        }
     }
 
 }

--- a/Journal.md
+++ b/Journal.md
@@ -443,6 +443,12 @@ Issue 60 moves the Mac importer from "bring me a GPX file" to "show me the walks
 
 The importer still keeps GPX as the spare key. If iCloud is signed out, restricted, temporarily unavailable, or just slow to deliver records, the app says so and leaves manual import open. When a synced walk does arrive, the Mac builds the same `.asmrroute` package without inventing a fake source GPX file. The route data came from CloudKit this time, so the package tells that truth plainly.
 
+### The Mac Importer Gets a Windshield
+
+Issue 101 gives the Mac importer the missing visual checkpoint: a real map preview before package export. A route file is no longer a sealed envelope of coordinates where the user has to trust the numbers. GPX imports and iCloud-synced recordings both become the same loaded route preview, drawn with start and finish markers and enough context to spot obvious nonsense before making an `.asmrroute`.
+
+That little workflow change matters. GPX import used to jump straight from file picker to package writer, which was efficient but blind. Now import means "load and inspect," and export is a separate deliberate action. That gives the next issue, point cleanup, a clean place to live without mutating the original GPX file or the CloudKit-backed recording.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- add a loaded route preview model and MapKit preview view for the Mac importer
- change GPX import and synced recording selection to load a preview before package export
- add a split Mac importer layout with the route map, start/finish markers, route metadata, and a separate Create Package action
- add Swift Testing coverage for route preview state and empty export failure

## Validation
- Xcode live diagnostics: clean for changed Mac app files and Mac importer tests
- Xcode MCP `BuildProject`: passed
- `git diff --check`: passed
- `xcodebuild test -project "ASMR Walk.xcodeproj" -scheme "ASMR Walk Mac Importer" -destination "platform=macOS" -derivedDataPath /private/tmp/ASMRWalkDerivedData101`: blocked by local command-line sandbox / Xcode macro plugin server (`swift-plugin-server` malformed response), same known environment issue from prior Mac importer PR

Closes #101