### PR TITLE
Add Mac route point cleanup

### DIFF
--- a/ASMR Walk Mac Importer/MacImporterView.swift
+++ b/ASMR Walk Mac Importer/MacImporterView.swift
@@ -140,21 +140,73 @@ struct MacImporterView: View {
                 }
             }
 
-            RoutePreviewMapView(route: viewModel.routePreview)
+            RoutePreviewMapView(
+                route: viewModel.routePreview,
+                selectedPointID: viewModel.selectedRoutePointID,
+                selectPoint: viewModel.selectRoutePoint
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .clipShape(.rect(cornerRadius: 8))
 
             if let routePreview = viewModel.routePreview {
-                HStack(spacing: 12) {
-                    Label(routePreview.distanceText, systemImage: "point.topleft.down.curvedto.point.bottomright.up")
-                    Label(routePreview.package.manifest.recordingSource.title, systemImage: "record.circle")
-                    Label(routePreview.package.manifest.mode.title, systemImage: routePreview.package.manifest.mode.systemImage)
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                routeSummary(routePreview)
+                routePointCleanupPanel(routePreview)
             }
         }
         .padding(24)
+    }
+
+    private func routeSummary(_ routePreview: RoutePreview) -> some View {
+        HStack(spacing: 12) {
+            Label(routePreview.distanceText, systemImage: "point.topleft.down.curvedto.point.bottomright.up")
+            Label(routePreview.recordingSource.title, systemImage: "record.circle")
+            Label(routePreview.recordingMode.title, systemImage: routePreview.recordingMode.systemImage)
+
+            if routePreview.hasPointEdits {
+                Label("\(routePreview.removedPointCount) removed", systemImage: "scissors")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    private func routePointCleanupPanel(_ routePreview: RoutePreview) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            if let selectedPoint = routePreview.point(id: viewModel.selectedRoutePointID) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Point \(selectedPoint.sourceIndex + 1)")
+                        .font(.headline)
+                    Text(selectedPoint.coordinateSummary)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Text(selectedPoint.timestamp, style: .time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("No Point Selected")
+                        .font(.headline)
+                    Text("Select a point marker on the map to remove it from the pending export.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Button("Delete Point", systemImage: "trash", role: .destructive) {
+                viewModel.deleteSelectedRoutePoint()
+            }
+            .disabled(viewModel.selectedRoutePointID == nil || routePreview.canDeletePoint == false)
+
+            Button("Reset Route", systemImage: "arrow.counterclockwise") {
+                viewModel.resetRoutePointEdits()
+            }
+            .disabled(routePreview.hasPointEdits == false)
+        }
+        .padding(12)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
     }
 
     private var statusPanel: some View {
@@ -196,7 +248,7 @@ struct MacImporterView: View {
                     viewModel.showFailure(error)
                 }
             }
-            .disabled(viewModel.routePreview?.routePointCount ?? 0 == 0)
+            .disabled(viewModel.routePreview?.routePointCount ?? 0 < 1)
 
             Button("Reveal Package", systemImage: "arrow.up.forward.app") {
                 viewModel.revealPackageInFinder()
@@ -264,6 +316,12 @@ private struct SyncedRecordingRow: View {
         }
         .padding(12)
         .background(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+    }
+}
+
+private extension RoutePreview.RoutePoint {
+    var coordinateSummary: String {
+        "\(latitude.formatted(.number.precision(.fractionLength(5)))), \(longitude.formatted(.number.precision(.fractionLength(5))))"
     }
 }
 

--- a/ASMR Walk Mac Importer/MacImporterViewModel.swift
+++ b/ASMR Walk Mac Importer/MacImporterViewModel.swift
@@ -16,6 +16,7 @@ final class MacImporterViewModel {
     private(set) var statusSystemImage = "point.topleft.down.curvedto.point.bottomright.up"
     private(set) var packageURL: URL?
     private(set) var routePreview: RoutePreview?
+    private(set) var selectedRoutePointID: RoutePreview.RoutePoint.ID?
 
     private let importer: ASMRGPXRouteImporter
     private let fileManager: FileManager
@@ -69,15 +70,53 @@ final class MacImporterViewModel {
     }
 
     func exportLoadedRoute() throws {
-        guard let package = routePreview?.package else {
+        guard let package = routePreview?.exportPackage else {
             throw ImportError.noRouteLoaded
         }
 
         try writePackage(package, successMessage: "\(package.manifest.routePointCount) route points were written to %@.")
     }
 
+    func selectRoutePoint(id: RoutePreview.RoutePoint.ID) {
+        guard routePreview?.point(id: id) != nil else {
+            return
+        }
+
+        selectedRoutePointID = id
+    }
+
+    func deleteSelectedRoutePoint() {
+        guard var preview = routePreview,
+              let selectedRoutePointID,
+              let removedPoint = preview.deletePoint(id: selectedRoutePointID) else {
+            return
+        }
+
+        routePreview = preview
+        self.selectedRoutePointID = nil
+        packageURL = nil
+        statusTitle = "Route Point Removed"
+        statusMessage = "Point \(removedPoint.sourceIndex + 1) was removed from the pending export. The source route was not changed."
+        statusSystemImage = "point.topleft.down.curvedto.point.bottomright.up"
+    }
+
+    func resetRoutePointEdits() {
+        guard var preview = routePreview, preview.hasPointEdits else {
+            return
+        }
+
+        preview.resetEdits()
+        routePreview = preview
+        selectedRoutePointID = nil
+        packageURL = nil
+        statusTitle = "Route Restored"
+        statusMessage = "\(preview.routePointCount) route points are ready to preview."
+        statusSystemImage = "arrow.counterclockwise"
+    }
+
     private func loadRoutePreview(_ package: ASMRRoutePackage, sourceDescription: String) {
         routePreview = RoutePreview(package: package, sourceDescription: sourceDescription)
+        selectedRoutePointID = nil
         packageURL = nil
         statusTitle = "Route Loaded"
         statusMessage = "\(package.manifest.routePointCount) route points are ready to preview."

--- a/ASMR Walk Mac Importer/RoutePreview.swift
+++ b/ASMR Walk Mac Importer/RoutePreview.swift
@@ -3,31 +3,65 @@
 //  ASMR Walk Mac Importer
 //
 
+import CoreLocation
 import Foundation
 
 struct RoutePreview: Equatable, Identifiable {
     let id: UUID
     let title: String
     let sourceDescription: String
-    let package: ASMRRoutePackage
+    private let originalPackage: ASMRRoutePackage
+    private let originalPoints: [RoutePoint]
+    private(set) var routePoints: [RoutePoint]
 
     init(package: ASMRRoutePackage, sourceDescription: String) {
         self.id = package.manifest.packageIdentifier
         self.title = package.manifest.title
         self.sourceDescription = sourceDescription
-        self.package = package
+        self.originalPackage = package
+        self.originalPoints = package.routePoints.enumerated().map { offset, point in
+            RoutePoint(sourceIndex: offset, point: point)
+        }
+        self.routePoints = originalPoints
     }
 
     var routePointCount: Int {
-        package.routePoints.count
+        routePoints.count
+    }
+
+    var removedPointCount: Int {
+        originalPoints.count - routePoints.count
+    }
+
+    var canDeletePoint: Bool {
+        routePoints.count > 1
+    }
+
+    var hasPointEdits: Bool {
+        removedPointCount > 0
+    }
+
+    var exportPackage: ASMRRoutePackage {
+        var manifest = originalPackage.manifest
+        manifest.routePointCount = routePoints.count
+        manifest.routeStartedAt = routePoints.first?.timestamp ?? manifest.routeStartedAt
+        manifest.routeEndedAt = routePoints.last?.timestamp ?? manifest.routeEndedAt
+        manifest.durationSeconds = max(0, manifest.routeEndedAt.timeIntervalSince(manifest.routeStartedAt))
+        manifest.distanceMeters = editedDistanceMeters
+
+        return ASMRRoutePackage(
+            manifest: manifest,
+            routePoints: routePoints.map(\.packagePoint),
+            sourceGPX: originalPackage.sourceGPX
+        )
     }
 
     var durationText: String {
-        Self.durationFormatter.string(from: package.manifest.durationSeconds) ?? "0:00"
+        Self.durationFormatter.string(from: originalPackage.manifest.durationSeconds) ?? "0:00"
     }
 
     var distanceText: String {
-        guard let distanceMeters = package.manifest.distanceMeters else {
+        guard let distanceMeters = originalPackage.manifest.distanceMeters else {
             return "Distance unavailable"
         }
 
@@ -49,4 +83,75 @@ struct RoutePreview: Equatable, Identifiable {
         formatter.numberFormatter.maximumFractionDigits = 2
         return formatter
     }()
+}
+
+extension RoutePreview {
+    struct RoutePoint: Equatable, Identifiable {
+        let id: UUID
+        let sourceIndex: Int
+        let packagePoint: ASMRRoutePackage.RoutePoint
+
+        init(sourceIndex: Int, point: ASMRRoutePackage.RoutePoint) {
+            self.id = UUID()
+            self.sourceIndex = sourceIndex
+            self.packagePoint = point
+        }
+
+        var timestamp: Date {
+            packagePoint.timestamp
+        }
+
+        var latitude: Double {
+            packagePoint.latitude
+        }
+
+        var longitude: Double {
+            packagePoint.longitude
+        }
+
+        var horizontalAccuracy: Double {
+            packagePoint.horizontalAccuracy
+        }
+    }
+
+    var recordingSource: WalkRecordingSource {
+        originalPackage.manifest.recordingSource
+    }
+
+    var recordingMode: RecordingMode {
+        originalPackage.manifest.mode
+    }
+
+    mutating func deletePoint(id pointID: RoutePoint.ID) -> RoutePoint? {
+        guard canDeletePoint,
+              let pointIndex = routePoints.firstIndex(where: { $0.id == pointID }) else {
+            return nil
+        }
+
+        return routePoints.remove(at: pointIndex)
+    }
+
+    mutating func resetEdits() {
+        routePoints = originalPoints
+    }
+
+    func point(id pointID: RoutePoint.ID?) -> RoutePoint? {
+        guard let pointID else {
+            return nil
+        }
+
+        return routePoints.first { $0.id == pointID }
+    }
+
+    private var editedDistanceMeters: Double {
+        guard routePoints.count > 1 else {
+            return 0
+        }
+
+        return zip(routePoints, routePoints.dropFirst()).reduce(0) { partialResult, pair in
+            let start = CLLocation(latitude: pair.0.latitude, longitude: pair.0.longitude)
+            let end = CLLocation(latitude: pair.1.latitude, longitude: pair.1.longitude)
+            return partialResult + end.distance(from: start)
+        }
+    }
 }

--- a/ASMR Walk Mac Importer/RoutePreviewMapView.swift
+++ b/ASMR Walk Mac Importer/RoutePreviewMapView.swift
@@ -8,8 +8,20 @@ import SwiftUI
 
 struct RoutePreviewMapView: View {
     let route: RoutePreview?
+    let selectedPointID: RoutePreview.RoutePoint.ID?
+    let selectPoint: (RoutePreview.RoutePoint.ID) -> Void
 
     @State private var position = MapCameraPosition.automatic
+
+    init(
+        route: RoutePreview?,
+        selectedPointID: RoutePreview.RoutePoint.ID? = nil,
+        selectPoint: @escaping (RoutePreview.RoutePoint.ID) -> Void = { _ in }
+    ) {
+        self.route = route
+        self.selectedPointID = selectedPointID
+        self.selectPoint = selectPoint
+    }
 
     var body: some View {
         Group {
@@ -29,6 +41,25 @@ struct RoutePreviewMapView: View {
                         Marker("Finish", systemImage: "flag.checkered", coordinate: end)
                             .tint(.red)
                     }
+
+                    ForEach(route.routePoints) { point in
+                        Annotation("Route point", coordinate: point.coordinate) {
+                            Button {
+                                selectPoint(point.id)
+                            } label: {
+                                ZStack {
+                                    Circle()
+                                        .fill(point.id == selectedPointID ? Color.red : Color.white)
+                                    Circle()
+                                        .strokeBorder(point.id == selectedPointID ? Color.white : Color.green, lineWidth: 2)
+                                }
+                                .frame(width: point.id == selectedPointID ? 14 : 10, height: point.id == selectedPointID ? 14 : 10)
+                                .shadow(radius: 1)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Route point \(point.sourceIndex + 1)")
+                        }
+                    }
                 }
                 .mapStyle(.standard(elevation: .realistic))
                 .mapControls {
@@ -40,6 +71,9 @@ struct RoutePreviewMapView: View {
                     position = route.cameraPosition
                 }
                 .onChange(of: route.id) {
+                    position = route.cameraPosition
+                }
+                .onChange(of: route.routePointCount) {
                     position = route.cameraPosition
                 }
                 .accessibilityLabel("Map showing the loaded walking route")
@@ -58,9 +92,7 @@ struct RoutePreviewMapView: View {
 
 private extension RoutePreview {
     var coordinates: [CLLocationCoordinate2D] {
-        package.routePoints.map {
-            CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
-        }
+        routePoints.map(\.coordinate)
     }
 
     var cameraPosition: MapCameraPosition {
@@ -90,5 +122,11 @@ private extension RoutePreview {
             width: width,
             height: height
         )
+    }
+}
+
+private extension RoutePreview.RoutePoint {
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 }

--- a/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
+++ b/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
@@ -89,8 +89,69 @@ struct ASMR_Walk_Mac_ImporterTests {
     }
 
     @Test func routePreviewSummarizesLoadedPackage() {
+        let package = makeRoutePackage()
+
+        let preview = RoutePreview(package: package, sourceDescription: "GPX file: Preview.gpx")
+
+        #expect(preview.id == package.manifest.packageIdentifier)
+        #expect(preview.title == "Preview Route")
+        #expect(preview.sourceDescription == "GPX file: Preview.gpx")
+        #expect(preview.routePointCount == 2)
+    }
+
+    @Test func deletingPreviewPointOnlyChangesPendingExport() throws {
+        let package = makeRoutePackage()
+        var preview = RoutePreview(package: package, sourceDescription: "GPX file: Preview.gpx")
+        let pointToDelete = try #require(preview.routePoints.first)
+
+        let deletedPoint = preview.deletePoint(id: pointToDelete.id)
+        let exportPackage = preview.exportPackage
+
+        #expect(deletedPoint?.sourceIndex == pointToDelete.sourceIndex)
+        #expect(preview.routePointCount == 1)
+        #expect(preview.removedPointCount == 1)
+        #expect(preview.hasPointEdits)
+        #expect(package.routePoints.count == 2)
+        #expect(exportPackage.manifest.routePointCount == 1)
+        #expect(exportPackage.routePoints.count == 1)
+        #expect(exportPackage.routePoints.first?.timestamp == package.routePoints.last?.timestamp)
+    }
+
+    @Test func previewCannotDeleteLastRoutePoint() throws {
+        var preview = RoutePreview(package: makeRoutePackage(), sourceDescription: "GPX file: Preview.gpx")
+        let firstPoint = try #require(preview.routePoints.first)
+        _ = preview.deletePoint(id: firstPoint.id)
+        let remainingPoint = try #require(preview.routePoints.first)
+
+        let deletedPoint = preview.deletePoint(id: remainingPoint.id)
+
+        #expect(deletedPoint == nil)
+        #expect(preview.routePointCount == 1)
+    }
+
+    @Test func resetPreviewEditsRestoresOriginalPoints() throws {
+        var preview = RoutePreview(package: makeRoutePackage(), sourceDescription: "GPX file: Preview.gpx")
+        let firstPoint = try #require(preview.routePoints.first)
+        _ = preview.deletePoint(id: firstPoint.id)
+
+        preview.resetEdits()
+
+        #expect(preview.routePointCount == 2)
+        #expect(preview.removedPointCount == 0)
+        #expect(preview.hasPointEdits == false)
+    }
+
+    @Test func exportWithoutLoadedRouteReportsFailure() {
+        let viewModel = MacImporterViewModel()
+
+        #expect(throws: MacImporterViewModel.ImportError.noRouteLoaded) {
+            try viewModel.exportLoadedRoute()
+        }
+    }
+
+    private func makeRoutePackage() -> ASMRRoutePackage {
         let start = Date(timeIntervalSince1970: 2_000)
-        let package = ASMRRoutePackage(
+        return ASMRRoutePackage(
             manifest: ASMRRoutePackage.Manifest(
                 packageIdentifier: UUID(uuidString: "48DB6037-9676-46F8-A272-E029A1E96F66")!,
                 title: "Preview Route",
@@ -126,21 +187,6 @@ struct ASMR_Walk_Mac_ImporterTests {
                 )
             ]
         )
-
-        let preview = RoutePreview(package: package, sourceDescription: "GPX file: Preview.gpx")
-
-        #expect(preview.id == package.manifest.packageIdentifier)
-        #expect(preview.title == "Preview Route")
-        #expect(preview.sourceDescription == "GPX file: Preview.gpx")
-        #expect(preview.routePointCount == 2)
-    }
-
-    @Test func exportWithoutLoadedRouteReportsFailure() {
-        let viewModel = MacImporterViewModel()
-
-        #expect(throws: MacImporterViewModel.ImportError.noRouteLoaded) {
-            try viewModel.exportLoadedRoute()
-        }
     }
 
 }

--- a/Journal.md
+++ b/Journal.md
@@ -449,6 +449,12 @@ Issue 101 gives the Mac importer the missing visual checkpoint: a real map previ
 
 That little workflow change matters. GPX import used to jump straight from file picker to package writer, which was efficient but blind. Now import means "load and inspect," and export is a separate deliberate action. That gives the next issue, point cleanup, a clean place to live without mutating the original GPX file or the CloudKit-backed recording.
 
+### The Mac Route Gets an Eraser
+
+Issue 102 adds the cleanup bench that naturally follows the preview map. Every route point is now a selectable marker, and the user can delete a bad point from the pending export before creating the `.asmrroute` package. The original GPX file and CloudKit-synced recording stay untouched; the importer works from a local preview copy, like marking up a photocopy instead of taking a pen to the only map.
+
+The guardrail is simple but important: the route can never be edited down to nothing. Deleting clears any previously exported package path, the route count updates immediately, and Reset restores the original point list. That keeps the workflow reversible until the user deliberately exports the cleaned package.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- let Mac importer users select route points directly on the map preview
- allow deleting selected points and resetting the pending route before export
- rebuild exported .asmrroute packages from the edited route copy while leaving source GPX/CloudKit recordings unchanged
- add Swift Testing coverage for delete/reset/export behavior

## Validation
- Xcode live diagnostics: clean for changed Mac app files and Mac importer tests
- Xcode MCP BuildProject: passed
- git diff --check: passed

Closes #102