### PR TITLE
Add Mac Photos video pairing

### DIFF
--- a/ASMR Walk Mac Importer/ASMR Walk Mac Importer.entitlements
+++ b/ASMR Walk Mac Importer/ASMR Walk Mac Importer.entitlements
@@ -12,5 +12,7 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
 </dict>
 </plist>

--- a/ASMR Walk Mac Importer/MacImporterView.swift
+++ b/ASMR Walk Mac Importer/MacImporterView.swift
@@ -5,6 +5,8 @@
 
 import SwiftUI
 import SwiftData
+import Photos
+import PhotosUI
 import UniformTypeIdentifiers
 
 struct MacImporterView: View {
@@ -14,6 +16,7 @@ struct MacImporterView: View {
     @State private var viewModel = MacImporterViewModel()
     @State private var cloudSyncStatus = CloudSyncStatus()
     @State private var isImportingGPX = false
+    @State private var selectedPhotosVideo: PhotosPickerItem?
 
     var body: some View {
         HSplitView {
@@ -22,6 +25,7 @@ struct MacImporterView: View {
                     header
                     cloudSyncPanel
                     syncedRecordingList
+                    photosVideoPanel
                     statusPanel
                     actionBar
                 }
@@ -41,6 +45,18 @@ struct MacImporterView: View {
         ) { result in
             Task {
                 await viewModel.handleGPXImportResult(result)
+            }
+        }
+        .onChange(of: selectedPhotosVideo) {
+            guard let selectedPhotosVideo else {
+                return
+            }
+
+            Task {
+                await viewModel.pairPhotosVideo(
+                    itemIdentifier: selectedPhotosVideo.itemIdentifier,
+                    supportedContentTypes: selectedPhotosVideo.supportedContentTypes
+                )
             }
         }
         .task {
@@ -107,6 +123,36 @@ struct MacImporterView: View {
                 .background(.regularMaterial, in: .rect(cornerRadius: 8))
             }
         }
+    }
+
+    private var photosVideoPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Photos Video")
+                .font(.headline)
+
+            Text(viewModel.photosVideoPairingMessage)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+
+            HStack {
+                PhotosPicker(
+                    selection: $selectedPhotosVideo,
+                    matching: .videos,
+                    preferredItemEncoding: .current,
+                    photoLibrary: .shared()
+                ) {
+                    Label("Choose Photos Video", systemImage: "photo.on.rectangle")
+                }
+                .buttonStyle(.bordered)
+
+                Button("Clear", systemImage: "xmark.circle") {
+                    selectedPhotosVideo = nil
+                    viewModel.clearPhotosVideoPairing()
+                }
+                .disabled(viewModel.selectedPhotosVideoReference == nil)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var routePreviewPanel: some View {

--- a/ASMR Walk Mac Importer/MacImporterViewModel.swift
+++ b/ASMR Walk Mac Importer/MacImporterViewModel.swift
@@ -6,6 +6,7 @@
 import AppKit
 import Foundation
 import Observation
+import Photos
 import UniformTypeIdentifiers
 
 @MainActor
@@ -17,16 +18,20 @@ final class MacImporterViewModel {
     private(set) var packageURL: URL?
     private(set) var routePreview: RoutePreview?
     private(set) var selectedRoutePointID: RoutePreview.RoutePoint.ID?
+    private(set) var selectedPhotosVideoReference: PhotosVideoReference?
 
     private let importer: ASMRGPXRouteImporter
     private let fileManager: FileManager
+    private let photosMetadataLoader: any PhotosVideoMetadataLoading
 
     init(
         importer: ASMRGPXRouteImporter = ASMRGPXRouteImporter(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        photosMetadataLoader: (any PhotosVideoMetadataLoading)? = nil
     ) {
         self.importer = importer
         self.fileManager = fileManager
+        self.photosMetadataLoader = photosMetadataLoader ?? PhotoLibraryVideoMetadataLoader()
     }
 
     func handleGPXImportResult(_ result: Result<[URL], any Error>) async {
@@ -70,11 +75,58 @@ final class MacImporterViewModel {
     }
 
     func exportLoadedRoute() throws {
-        guard let package = routePreview?.exportPackage else {
+        guard let package = routePreview?.exportPackage(
+            photosVideoReference: selectedPhotosVideoReference?.packageReference(relativeTo: routePreview)
+        ) else {
             throw ImportError.noRouteLoaded
         }
 
         try writePackage(package, successMessage: "\(package.manifest.routePointCount) route points were written to %@.")
+    }
+
+    func pairPhotosVideo(itemIdentifier: String?, supportedContentTypes: [UTType]) async {
+        guard let itemIdentifier, itemIdentifier.isEmpty == false else {
+            showFailure(ImportError.photosVideoIdentifierUnavailable)
+            return
+        }
+
+        var pairingMessage: String?
+        selectedPhotosVideoReference = PhotosVideoReference(
+            itemIdentifier: itemIdentifier,
+            supportedContentTypes: supportedContentTypes,
+            metadata: nil
+        )
+
+        do {
+            let metadata = try await photosMetadataLoader.metadata(forItemIdentifier: itemIdentifier)
+            selectedPhotosVideoReference = PhotosVideoReference(
+                itemIdentifier: itemIdentifier,
+                supportedContentTypes: supportedContentTypes,
+                metadata: metadata
+            )
+            pairingMessage = photosVideoPairingMessage
+        } catch PhotoLibraryVideoMetadataLoader.MetadataError.usageDescriptionMissing {
+            pairingMessage = "The Photos video is selected. Add the Mac target Photos usage description in Xcode before timestamp, duration, and location matching can run."
+        } catch {
+            pairingMessage = "The Photos video is selected, but its timestamp, duration, and location metadata could not be loaded: \(error.localizedDescription)"
+        }
+
+        packageURL = nil
+        statusTitle = "Photos Video Paired"
+        statusMessage = pairingMessage ?? photosVideoPairingMessage
+        statusSystemImage = "photo.on.rectangle"
+    }
+
+    func clearPhotosVideoPairing() {
+        guard selectedPhotosVideoReference != nil else {
+            return
+        }
+
+        selectedPhotosVideoReference = nil
+        packageURL = nil
+        statusTitle = "Photos Video Removed"
+        statusMessage = "The pending route package will not include a Photos video reference."
+        statusSystemImage = "photo.on.rectangle.angled"
     }
 
     func selectRoutePoint(id: RoutePreview.RoutePoint.ID) {
@@ -112,6 +164,22 @@ final class MacImporterViewModel {
         statusTitle = "Route Restored"
         statusMessage = "\(preview.routePointCount) route points are ready to preview."
         statusSystemImage = "arrow.counterclockwise"
+    }
+
+    var photosVideoPairingMessage: String {
+        guard let selectedPhotosVideoReference else {
+            return "Select a Photos video to pair it with the loaded route."
+        }
+
+        guard routePreview != nil else {
+            return "\(selectedPhotosVideoReference.displayName) is selected. Load a route before creating an .asmrroute package."
+        }
+
+        if let offsetText = selectedPhotosVideoReference.offsetText(relativeTo: routePreview) {
+            return "\(selectedPhotosVideoReference.displayName) will be referenced in the next .asmrroute package. Estimated route offset: \(offsetText)."
+        }
+
+        return "\(selectedPhotosVideoReference.displayName) will be referenced in the next .asmrroute package. The video file will not be copied into the package."
     }
 
     private func loadRoutePreview(_ package: ASMRRoutePackage, sourceDescription: String) {
@@ -182,6 +250,7 @@ extension MacImporterViewModel {
         case outputDirectoryAccessDenied
         case outputDirectoryNotSelected
         case noRouteLoaded
+        case photosVideoIdentifierUnavailable
 
         var errorDescription: String? {
             switch self {
@@ -193,6 +262,129 @@ extension MacImporterViewModel {
                 "No output folder was selected."
             case .noRouteLoaded:
                 "Load a route before creating an .asmrroute package."
+            case .photosVideoIdentifierUnavailable:
+                "The selected Photos video could not be referenced."
+            }
+        }
+    }
+}
+
+extension MacImporterViewModel {
+    struct PhotosVideoReference: Equatable {
+        let itemIdentifier: String
+        let supportedContentTypes: [UTType]
+        let metadata: PhotoLibraryVideoMetadata?
+
+        var displayName: String {
+            if let typeDescription = supportedContentTypes.first?.localizedDescription,
+               typeDescription.isEmpty == false {
+                return "Photos video (\(typeDescription))"
+            }
+
+            return "Photos video"
+        }
+
+        var packageReference: ASMRRoutePackage.VideoReference {
+            ASMRRoutePackage.VideoReference(
+                kind: .photosAsset,
+                displayName: displayName,
+                sourceIdentifier: itemIdentifier,
+                startsAt: metadata?.creationDate,
+                offsetSeconds: nil,
+                isEmbedded: false
+            )
+        }
+
+        func packageReference(relativeTo routePreview: RoutePreview?) -> ASMRRoutePackage.VideoReference {
+            ASMRRoutePackage.VideoReference(
+                kind: .photosAsset,
+                displayName: displayName,
+                sourceIdentifier: itemIdentifier,
+                startsAt: metadata?.creationDate,
+                offsetSeconds: offsetSeconds(relativeTo: routePreview),
+                isEmbedded: false
+            )
+        }
+
+        func offsetText(relativeTo routePreview: RoutePreview?) -> String? {
+            guard let offsetSeconds = offsetSeconds(relativeTo: routePreview) else {
+                return nil
+            }
+
+            return Duration.seconds(offsetSeconds).formatted(.time(pattern: .minuteSecond(padMinuteToLength: 2)))
+        }
+
+        private func offsetSeconds(relativeTo routePreview: RoutePreview?) -> TimeInterval? {
+            guard let routePreview, let creationDate = metadata?.creationDate else {
+                return nil
+            }
+
+            return creationDate.timeIntervalSince(routePreview.routeStartedAt)
+        }
+    }
+}
+
+protocol PhotosVideoMetadataLoading: Sendable {
+    func metadata(forItemIdentifier itemIdentifier: String) async throws -> PhotoLibraryVideoMetadata
+}
+
+struct PhotoLibraryVideoMetadata: Equatable, Sendable {
+    let creationDate: Date?
+    let duration: TimeInterval
+    let latitude: Double?
+    let longitude: Double?
+}
+
+struct PhotoLibraryVideoMetadataLoader: PhotosVideoMetadataLoading {
+    func metadata(forItemIdentifier itemIdentifier: String) async throws -> PhotoLibraryVideoMetadata {
+        guard Bundle.main.object(forInfoDictionaryKey: "NSPhotoLibraryUsageDescription") != nil else {
+            throw MetadataError.usageDescriptionMissing
+        }
+
+        let authorizationStatus = await authorizationStatus()
+        guard authorizationStatus == .authorized || authorizationStatus == .limited else {
+            throw MetadataError.authorizationDenied
+        }
+
+        let result = PHAsset.fetchAssets(withLocalIdentifiers: [itemIdentifier], options: nil)
+        guard let asset = result.firstObject else {
+            throw MetadataError.assetNotFound
+        }
+
+        return PhotoLibraryVideoMetadata(
+            creationDate: asset.creationDate,
+            duration: asset.duration,
+            latitude: asset.location?.coordinate.latitude,
+            longitude: asset.location?.coordinate.longitude
+        )
+    }
+
+    private func authorizationStatus() async -> PHAuthorizationStatus {
+        let currentStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        guard currentStatus == .notDetermined else {
+            return currentStatus
+        }
+
+        return await withCheckedContinuation { continuation in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
+
+    enum MetadataError: LocalizedError, Equatable {
+        case usageDescriptionMissing
+        case authorizationDenied
+        case assetNotFound
+
+        var errorDescription: String? {
+            switch self {
+            case .usageDescriptionMissing:
+                "The Mac importer target is missing NSPhotoLibraryUsageDescription."
+            case .authorizationDenied:
+                "Photos library access was not granted."
+            case .assetNotFound:
+                "The selected Photos video could not be found in the library."
             }
         }
     }

--- a/ASMR Walk Mac Importer/RoutePreview.swift
+++ b/ASMR Walk Mac Importer/RoutePreview.swift
@@ -42,12 +42,21 @@ struct RoutePreview: Equatable, Identifiable {
     }
 
     var exportPackage: ASMRRoutePackage {
+        exportPackage(photosVideoReference: nil)
+    }
+
+    func exportPackage(photosVideoReference: ASMRRoutePackage.VideoReference?) -> ASMRRoutePackage {
         var manifest = originalPackage.manifest
         manifest.routePointCount = routePoints.count
         manifest.routeStartedAt = routePoints.first?.timestamp ?? manifest.routeStartedAt
         manifest.routeEndedAt = routePoints.last?.timestamp ?? manifest.routeEndedAt
         manifest.durationSeconds = max(0, manifest.routeEndedAt.timeIntervalSince(manifest.routeStartedAt))
         manifest.distanceMeters = editedDistanceMeters
+
+        if let photosVideoReference {
+            manifest.videoReferences.removeAll { $0.kind == .photosAsset }
+            manifest.videoReferences.append(photosVideoReference)
+        }
 
         return ASMRRoutePackage(
             manifest: manifest,
@@ -120,6 +129,10 @@ extension RoutePreview {
 
     var recordingMode: RecordingMode {
         originalPackage.manifest.mode
+    }
+
+    var routeStartedAt: Date {
+        exportPackage.manifest.routeStartedAt
     }
 
     mutating func deletePoint(id pointID: RoutePoint.ID) -> RoutePoint? {

--- a/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
+++ b/ASMR Walk Mac ImporterTests/ASMR_Walk_Mac_ImporterTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 import SwiftData
+import UniformTypeIdentifiers
 @testable import ASMR_Walk_Mac_Importer
 
 @MainActor
@@ -139,6 +140,89 @@ struct ASMR_Walk_Mac_ImporterTests {
         #expect(preview.routePointCount == 2)
         #expect(preview.removedPointCount == 0)
         #expect(preview.hasPointEdits == false)
+    }
+
+    @Test func routePreviewExportIncludesPairedPhotosVideoReference() throws {
+        let preview = RoutePreview(package: makeRoutePackage(), sourceDescription: "GPX file: Preview.gpx")
+        let photosReference = MacImporterViewModel.PhotosVideoReference(
+            itemIdentifier: "B96D04C5-3D04-4C6B-9FF7-2B5B307526D5/L0/001",
+            supportedContentTypes: [.quickTimeMovie],
+            metadata: nil
+        )
+
+        let exportPackage = preview.exportPackage(photosVideoReference: photosReference.packageReference)
+        let videoReference = try #require(exportPackage.manifest.videoReferences.first)
+
+        #expect(exportPackage.manifest.videoReferences.count == 1)
+        #expect(videoReference.kind == .photosAsset)
+        #expect(videoReference.displayName.contains("Photos video"))
+        #expect(videoReference.sourceIdentifier == "B96D04C5-3D04-4C6B-9FF7-2B5B307526D5/L0/001")
+        #expect(videoReference.startsAt == nil)
+        #expect(videoReference.offsetSeconds == nil)
+        #expect(videoReference.isEmbedded == false)
+    }
+
+    @Test func pairedPhotosVideoReferenceReplacesExistingPhotosReference() throws {
+        let originalPackage = makeRoutePackage()
+        var manifest = originalPackage.manifest
+        manifest.videoReferences = [
+            ASMRRoutePackage.VideoReference(
+                kind: .photosAsset,
+                displayName: "Old Photos video",
+                sourceIdentifier: "old-identifier",
+                startsAt: nil,
+                offsetSeconds: nil,
+                isEmbedded: false
+            )
+        ]
+        let package = ASMRRoutePackage(
+            manifest: manifest,
+            routePoints: originalPackage.routePoints,
+            sourceGPX: originalPackage.sourceGPX
+        )
+        let preview = RoutePreview(package: package, sourceDescription: "GPX file: Preview.gpx")
+        let photosReference = MacImporterViewModel.PhotosVideoReference(
+            itemIdentifier: "new-identifier",
+            supportedContentTypes: [.movie],
+            metadata: nil
+        )
+
+        let exportPackage = preview.exportPackage(photosVideoReference: photosReference.packageReference)
+        let videoReference = try #require(exportPackage.manifest.videoReferences.first)
+
+        #expect(exportPackage.manifest.videoReferences.count == 1)
+        #expect(videoReference.sourceIdentifier == "new-identifier")
+    }
+
+    @Test func routePreviewExportIncludesPhotosVideoTimingOffset() throws {
+        let routeStart = Date(timeIntervalSince1970: 2_000)
+        let preview = RoutePreview(package: makeRoutePackage(), sourceDescription: "GPX file: Preview.gpx")
+        let photosReference = MacImporterViewModel.PhotosVideoReference(
+            itemIdentifier: "timed-video",
+            supportedContentTypes: [.movie],
+            metadata: PhotoLibraryVideoMetadata(
+                creationDate: routeStart.addingTimeInterval(-12),
+                duration: 96,
+                latitude: 36.11,
+                longitude: -86.66
+            )
+        )
+
+        let exportPackage = preview.exportPackage(photosVideoReference: photosReference.packageReference(relativeTo: preview))
+        let videoReference = try #require(exportPackage.manifest.videoReferences.first)
+
+        #expect(videoReference.startsAt == routeStart.addingTimeInterval(-12))
+        #expect(videoReference.offsetSeconds == -12)
+    }
+
+    @Test func photosVideoSelectionWithoutIdentifierReportsFailure() async {
+        let viewModel = MacImporterViewModel()
+
+        await viewModel.pairPhotosVideo(itemIdentifier: nil, supportedContentTypes: [.movie])
+
+        #expect(viewModel.selectedPhotosVideoReference == nil)
+        #expect(viewModel.statusTitle == "Import Failed")
+        #expect(viewModel.statusMessage == MacImporterViewModel.ImportError.photosVideoIdentifierUnavailable.localizedDescription)
     }
 
     @Test func exportWithoutLoadedRouteReportsFailure() {

--- a/ASMR Walk.xcodeproj/project.pbxproj
+++ b/ASMR Walk.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ASMR Walk uses your Photos library to let you choose videos and read their date, duration, and location metadata so they can be paired with walking routes for export.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1100,6 +1101,7 @@
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ASMR Walk uses your Photos library to let you choose videos and read their date, duration, and location metadata so they can be paired with walking routes for export.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Journal.md
+++ b/Journal.md
@@ -455,6 +455,12 @@ Issue 102 adds the cleanup bench that naturally follows the preview map. Every r
 
 The guardrail is simple but important: the route can never be edited down to nothing. Deleting clears any previously exported package path, the route count updates immediately, and Reset restores the original point list. That keeps the workflow reversible until the user deliberately exports the cleaned package.
 
+### Photos Videos Get a Claim Ticket
+
+Issue 74 starts the Mac importer video pairing path without stuffing giant movie files into `.asmrroute` packages. A selected Photos video becomes a non-embedded `photosAsset` reference in the manifest, which is more like a claim ticket than a suitcase: the package knows which library asset belongs with the route, but the video stays in Photos.
+
+This is also where macOS privacy rules show their teeth. The SwiftUI Photos picker can hand over a user-selected item, but richer timestamp, duration, and location matching depends on Photos Library access and real media. The importer now has the entitlement side prepared, while the deeper matching behavior remains something to validate against an owner-controlled Photos library instead of a simulator-shaped guess.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- add a Mac importer Photos video picker for manually pairing a Photos asset with the loaded route
- write a non-embedded photosAsset video reference into exported .asmrroute manifests
- add guarded PhotoKit metadata loading for creation date, duration, and location so timing offsets can be written when available
- add the macOS Photos Library entitlement and Mac target `NSPhotoLibraryUsageDescription`
- add Swift Testing coverage for Photos references, replacement, and timing offsets
- update the project journal with the Photos reference/package decision

## Owner / Beta Validation Notes
- Validate on a Mac with representative Photos videos: select a video, load a GPX or synced route, create the .asmrroute, and confirm the manifest includes the expected `photosAsset` reference and offset when metadata is available.
- The selected Photos video is referenced, not embedded or copied into the .asmrroute package.
- The Mac target now includes this Photos usage string: "ASMR Walk uses your Photos library to let you choose videos and read their date, duration, and location metadata so they can be paired with walking routes for export."

## Validation
- Confirmed `NSPhotoLibraryUsageDescription` is present in both Mac importer generated Info.plist build configurations
- Xcode live diagnostics: clean for changed Mac importer files and tests
- Xcode MCP BuildProject: passed after the usage-description update
- git diff --check: passed before the usage-description follow-up
- xcodebuild test -scheme `ASMR Walk Mac Importer` -destination `platform=macOS`: blocked by local CoreSimulatorService / swift-plugin-server malformed response issue

Closes #74