### PR TITLE
Add FxPlug route overlay target

### DIFF
--- a/ASMR Walk Route Overlay/ASMR_Walk_Route_OverlayApp.swift
+++ b/ASMR Walk Route Overlay/ASMR_Walk_Route_OverlayApp.swift
@@ -1,0 +1,17 @@
+//
+//  ASMR_Walk_Route_OverlayApp.swift
+//  ASMR Walk Route Overlay
+//
+//  Created by David Heath on 9/5/26.
+//
+
+import SwiftUI
+
+@main
+struct ASMR_Walk_Route_OverlayApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ASMR Walk Route Overlay/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ASMR Walk Route Overlay/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMR Walk Route Overlay/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ASMR Walk Route Overlay/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMR Walk Route Overlay/Assets.xcassets/Contents.json
+++ b/ASMR Walk Route Overlay/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ASMR Walk Route Overlay/ContentView.swift
+++ b/ASMR Walk Route Overlay/ContentView.swift
@@ -1,0 +1,28 @@
+//
+//  ContentView.swift
+//  ASMR Walk Route Overlay
+//
+//  Created by David Heath on 9/5/26.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("ASMR Walk Route Overlay", systemImage: "point.topleft.down.curvedto.point.bottomright.up")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label("FxPlug generator installed", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text("Open Motion or Final Cut Pro to use the ASMR Walk generator after this app has been built and launched.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(minWidth: 420, alignment: .leading)
+        .padding(28)
+    }
+}

--- a/ASMR Walk Route OverlayTests/ASMR_Walk_Route_OverlayTests.swift
+++ b/ASMR Walk Route OverlayTests/ASMR_Walk_Route_OverlayTests.swift
@@ -1,0 +1,19 @@
+//
+//  ASMR_Walk_Route_OverlayTests.swift
+//  ASMR Walk Route OverlayTests
+//
+//  Created by David Heath on 9/5/26.
+//
+
+import Testing
+@testable import ASMR_Walk_Route_Overlay
+
+struct ASMR_Walk_Route_OverlayTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // Swift Testing Documentation
+        // https://developer.apple.com/documentation/testing
+    }
+
+}

--- a/ASMR Walk Route OverlayUITests/ASMR_Walk_Route_OverlayUITests.swift
+++ b/ASMR Walk Route OverlayUITests/ASMR_Walk_Route_OverlayUITests.swift
@@ -1,0 +1,43 @@
+//
+//  ASMR_Walk_Route_OverlayUITests.swift
+//  ASMR Walk Route OverlayUITests
+//
+//  Created by David Heath on 9/5/26.
+//
+
+import XCTest
+
+final class ASMR_Walk_Route_OverlayUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/ASMR Walk Route OverlayUITests/ASMR_Walk_Route_OverlayUITestsLaunchTests.swift
+++ b/ASMR Walk Route OverlayUITests/ASMR_Walk_Route_OverlayUITestsLaunchTests.swift
@@ -1,0 +1,35 @@
+//
+//  ASMR_Walk_Route_OverlayUITestsLaunchTests.swift
+//  ASMR Walk Route OverlayUITests
+//
+//  Created by David Heath on 9/5/26.
+//
+
+import XCTest
+
+final class ASMR_Walk_Route_OverlayUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ASMR Walk.xcodeproj/project.pbxproj
+++ b/ASMR Walk.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A51DD6A304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 3A51DD5F304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		3A51DD74304CB28B00B3CEF1 /* FxPlug.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A51DD73304CB28B00B3CEF1 /* FxPlug.framework */; };
+		3A51DD75304CB28B00B3CEF1 /* FxPlug.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3A51DD73304CB28B00B3CEF1 /* FxPlug.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3A51DD78304CB29E00B3CEF1 /* PluginManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A51DD77304CB29E00B3CEF1 /* PluginManager.framework */; };
+		3A51DD79304CB29E00B3CEF1 /* PluginManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3A51DD77304CB29E00B3CEF1 /* PluginManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3A51DD7D304CB87800B3CEF1 /* ASMRWalkRouteOverlay.pluginkit in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A51DD5F304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3A6821202FF06A2A0012C321 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3A68211F2FF06A2A0012C321 /* Launch Screen.storyboard */; };
 		3AA4BDA9304398A400E5D8A6 /* ASMRWalk Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3AC8940E300431E6003AC68B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AC8940D300431E6003AC68B /* PrivacyInfo.xcprivacy */; };
@@ -41,6 +47,27 @@
 			remoteGlobalIDString = 3A4F4CEC3044A7EE00D6ADD3;
 			remoteInfo = "ASMR Walk Mac Importer";
 		};
+		3A51DD41304CAFAD00B3CEF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A51DD33304CAFAC00B3CEF1;
+			remoteInfo = "ASMR Walk Route Overlay";
+		};
+		3A51DD4B304CAFAD00B3CEF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A51DD33304CAFAC00B3CEF1;
+			remoteInfo = "ASMR Walk Route Overlay";
+		};
+		3A51DD68304CB00C00B3CEF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A51DD5E304CB00C00B3CEF1;
+			remoteInfo = ASMRWalkRouteOverlay;
+		};
 		3AA4BD96304398A400E5D8A6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3A3E1F102FC3DE3500CFEE4A /* Project object */;
@@ -65,6 +92,48 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3A51DD6F304CB00C00B3CEF1 /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				3A51DD6A304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD70304CB0DA00B3CEF1 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD76304CB28B00B3CEF1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3A51DD75304CB28B00B3CEF1 /* FxPlug.framework in Embed Frameworks */,
+				3A51DD79304CB29E00B3CEF1 /* PluginManager.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD7C304CB85800B3CEF1 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				3A51DD7D304CB87800B3CEF1 /* ASMRWalkRouteOverlay.pluginkit in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3AA4BDAA304398A400E5D8A6 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -85,6 +154,12 @@
 		3A4F4CED3044A7EE00D6ADD3 /* ASMR Walk Mac Importer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASMR Walk Mac Importer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A4F4CF93044A7EF00D6ADD3 /* ASMR Walk Mac ImporterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR Walk Mac ImporterTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A4F4D033044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR Walk Mac ImporterUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A51DD34304CAFAC00B3CEF1 /* ASMR Walk Route Overlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASMR Walk Route Overlay.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A51DD40304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR Walk Route OverlayTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A51DD4A304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMR Walk Route OverlayUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A51DD5F304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = ASMRWalkRouteOverlay.pluginkit; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A51DD73304CB28B00B3CEF1 /* FxPlug.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FxPlug.framework; path = ../../../../../Library/Developer/Frameworks/FxPlug.framework; sourceTree = "<group>"; };
+		3A51DD77304CB29E00B3CEF1 /* PluginManager.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PluginManager.framework; path = ../../../../../Library/Developer/Frameworks/PluginManager.framework; sourceTree = "<group>"; };
 		3A68211F2FF06A2A0012C321 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		3AA4BD89304398A400E5D8A6 /* ASMRWalk Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ASMRWalk Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA4BD95304398A400E5D8A6 /* ASMRWalk Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ASMRWalk Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +174,13 @@
 				"ASMR-Walk-Info.plist",
 			);
 			target = 3A3E1F172FC3DE3500CFEE4A /* ASMR Walk */;
+		};
+		3A51DD6B304CB00C00B3CEF1 /* Exceptions for "ASMRWalkRouteOverlay" folder in "ASMRWalkRouteOverlay" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 3A51DD5E304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -134,6 +216,29 @@
 		3A4F4D063044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "ASMR Walk Mac ImporterUITests";
+			sourceTree = "<group>";
+		};
+		3A51DD35304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMR Walk Route Overlay";
+			sourceTree = "<group>";
+		};
+		3A51DD43304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMR Walk Route OverlayTests";
+			sourceTree = "<group>";
+		};
+		3A51DD4D304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "ASMR Walk Route OverlayUITests";
+			sourceTree = "<group>";
+		};
+		3A51DD60304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3A51DD6B304CB00C00B3CEF1 /* Exceptions for "ASMRWalkRouteOverlay" folder in "ASMRWalkRouteOverlay" target */,
+			);
+			path = ASMRWalkRouteOverlay;
 			sourceTree = "<group>";
 		};
 		3AA4BD8A304398A400E5D8A6 /* ASMRWalk Watch App */ = {
@@ -196,6 +301,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3A51DD31304CAFAC00B3CEF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD3D304CAFAD00B3CEF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD47304CAFAD00B3CEF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD5C304CB00C00B3CEF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A51DD74304CB28B00B3CEF1 /* FxPlug.framework in Frameworks */,
+				3A51DD78304CB29E00B3CEF1 /* PluginManager.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3AA4BD86304398A400E5D8A6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -234,6 +369,11 @@
 				3A4F4CEE3044A7EE00D6ADD3 /* ASMR Walk Mac Importer */,
 				3A4F4CFC3044A7EF00D6ADD3 /* ASMR Walk Mac ImporterTests */,
 				3A4F4D063044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests */,
+				3A51DD35304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */,
+				3A51DD43304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests */,
+				3A51DD4D304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests */,
+				3A51DD60304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */,
+				3A51DD72304CB28B00B3CEF1 /* Frameworks */,
 				3A3E1F192FC3DE3500CFEE4A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -250,8 +390,21 @@
 				3A4F4CED3044A7EE00D6ADD3 /* ASMR Walk Mac Importer.app */,
 				3A4F4CF93044A7EF00D6ADD3 /* ASMR Walk Mac ImporterTests.xctest */,
 				3A4F4D033044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests.xctest */,
+				3A51DD34304CAFAC00B3CEF1 /* ASMR Walk Route Overlay.app */,
+				3A51DD40304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests.xctest */,
+				3A51DD4A304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests.xctest */,
+				3A51DD5F304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		3A51DD72304CB28B00B3CEF1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3A51DD77304CB29E00B3CEF1 /* PluginManager.framework */,
+				3A51DD73304CB28B00B3CEF1 /* FxPlug.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -334,10 +487,12 @@
 				3A4F4CE93044A7EE00D6ADD3 /* Sources */,
 				3A4F4CEA3044A7EE00D6ADD3 /* Frameworks */,
 				3A4F4CEB3044A7EE00D6ADD3 /* Resources */,
+				3A51DD6F304CB00C00B3CEF1 /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3A51DD69304CB00C00B3CEF1 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				3A4F4CEE3044A7EE00D6ADD3 /* ASMR Walk Mac Importer */,
@@ -394,6 +549,99 @@
 			productName = "ASMR Walk Mac ImporterUITests";
 			productReference = 3A4F4D033044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		3A51DD33304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A51DD58304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route Overlay" */;
+			buildPhases = (
+				3A51DD30304CAFAC00B3CEF1 /* Sources */,
+				3A51DD31304CAFAC00B3CEF1 /* Frameworks */,
+				3A51DD32304CAFAC00B3CEF1 /* Resources */,
+				3A51DD7C304CB85800B3CEF1 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3A51DD35304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */,
+			);
+			name = "ASMR Walk Route Overlay";
+			packageProductDependencies = (
+			);
+			productName = "ASMR Walk Route Overlay";
+			productReference = 3A51DD34304CAFAC00B3CEF1 /* ASMR Walk Route Overlay.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3A51DD3F304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A51DD59304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route OverlayTests" */;
+			buildPhases = (
+				3A51DD3C304CAFAD00B3CEF1 /* Sources */,
+				3A51DD3D304CAFAD00B3CEF1 /* Frameworks */,
+				3A51DD3E304CAFAD00B3CEF1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3A51DD42304CAFAD00B3CEF1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3A51DD43304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests */,
+			);
+			name = "ASMR Walk Route OverlayTests";
+			packageProductDependencies = (
+			);
+			productName = "ASMR Walk Route OverlayTests";
+			productReference = 3A51DD40304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		3A51DD49304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A51DD5A304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route OverlayUITests" */;
+			buildPhases = (
+				3A51DD46304CAFAD00B3CEF1 /* Sources */,
+				3A51DD47304CAFAD00B3CEF1 /* Frameworks */,
+				3A51DD48304CAFAD00B3CEF1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3A51DD4C304CAFAD00B3CEF1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3A51DD4D304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests */,
+			);
+			name = "ASMR Walk Route OverlayUITests";
+			packageProductDependencies = (
+			);
+			productName = "ASMR Walk Route OverlayUITests";
+			productReference = 3A51DD4A304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		3A51DD5E304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A51DD6C304CB00C00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMRWalkRouteOverlay" */;
+			buildPhases = (
+				3A51DD5B304CB00C00B3CEF1 /* Sources */,
+				3A51DD5C304CB00C00B3CEF1 /* Frameworks */,
+				3A51DD5D304CB00C00B3CEF1 /* Resources */,
+				3A51DD70304CB0DA00B3CEF1 /* CopyFiles */,
+				3A51DD76304CB28B00B3CEF1 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3A51DD60304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */,
+			);
+			name = ASMRWalkRouteOverlay;
+			packageProductDependencies = (
+			);
+			productName = ASMRWalkRouteOverlay;
+			productReference = 3A51DD5F304CB00C00B3CEF1 /* ASMRWalkRouteOverlay.pluginkit */;
+			productType = "com.apple.product-type.xpc-service";
 		};
 		3AA4BD88304398A400E5D8A6 /* ASMRWalk Watch App */ = {
 			isa = PBXNativeTarget;
@@ -495,6 +743,20 @@
 						CreatedOnToolsVersion = 26.6;
 						TestTargetID = 3A4F4CEC3044A7EE00D6ADD3;
 					};
+					3A51DD33304CAFAC00B3CEF1 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+					3A51DD3F304CAFAD00B3CEF1 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = 3A51DD33304CAFAC00B3CEF1;
+					};
+					3A51DD49304CAFAD00B3CEF1 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = 3A51DD33304CAFAC00B3CEF1;
+					};
+					3A51DD5E304CB00C00B3CEF1 = {
+						CreatedOnToolsVersion = 26.6;
+					};
 					3AA4BD88304398A400E5D8A6 = {
 						CreatedOnToolsVersion = 26.6;
 					};
@@ -531,6 +793,10 @@
 				3A4F4CEC3044A7EE00D6ADD3 /* ASMR Walk Mac Importer */,
 				3A4F4CF83044A7EF00D6ADD3 /* ASMR Walk Mac ImporterTests */,
 				3A4F4D023044A7EF00D6ADD3 /* ASMR Walk Mac ImporterUITests */,
+				3A51DD33304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */,
+				3A51DD3F304CAFAD00B3CEF1 /* ASMR Walk Route OverlayTests */,
+				3A51DD49304CAFAD00B3CEF1 /* ASMR Walk Route OverlayUITests */,
+				3A51DD5E304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */,
 			);
 		};
 /* End PBXProject section */
@@ -574,6 +840,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3A4F4D013044A7EF00D6ADD3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD32304CAFAC00B3CEF1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD3E304CAFAD00B3CEF1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD48304CAFAD00B3CEF1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD5D304CB00C00B3CEF1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -646,6 +940,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3A51DD30304CAFAC00B3CEF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD3C304CAFAD00B3CEF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD46304CAFAD00B3CEF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A51DD5B304CB00C00B3CEF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3AA4BD85304398A400E5D8A6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -689,6 +1011,21 @@
 			isa = PBXTargetDependency;
 			target = 3A4F4CEC3044A7EE00D6ADD3 /* ASMR Walk Mac Importer */;
 			targetProxy = 3A4F4D043044A7EF00D6ADD3 /* PBXContainerItemProxy */;
+		};
+		3A51DD42304CAFAD00B3CEF1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A51DD33304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */;
+			targetProxy = 3A51DD41304CAFAD00B3CEF1 /* PBXContainerItemProxy */;
+		};
+		3A51DD4C304CAFAD00B3CEF1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A51DD33304CAFAC00B3CEF1 /* ASMR Walk Route Overlay */;
+			targetProxy = 3A51DD4B304CAFAD00B3CEF1 /* PBXContainerItemProxy */;
+		};
+		3A51DD69304CB00C00B3CEF1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A51DD5E304CB00C00B3CEF1 /* ASMRWalkRouteOverlay */;
+			targetProxy = 3A51DD68304CB00C00B3CEF1 /* PBXContainerItemProxy */;
 		};
 		3AA4BD97304398A400E5D8A6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1034,6 +1371,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "ASMR Walk Mac Importer/ASMR Walk Mac Importer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1054,6 +1392,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ASMR Walk uses your Photos library to let you choose videos and read their date, duration, and location metadata so they can be paired with walking routes for export.";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1080,6 +1419,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "ASMR Walk Mac Importer/ASMR Walk Mac Importer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1100,6 +1440,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ASMR Walk uses your Photos library to let you choose videos and read their date, duration, and location metadata so they can be paired with walking routes for export.";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1204,6 +1545,234 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = "ASMR Walk Mac Importer";
+			};
+			name = Release;
+		};
+		3A51DD52304CAFAD00B3CEF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-Overlay";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3A51DD53304CAFAD00B3CEF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-Overlay";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		3A51DD54304CAFAD00B3CEF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-OverlayTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ASMR Walk Route Overlay.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ASMR Walk Route Overlay";
+			};
+			name = Debug;
+		};
+		3A51DD55304CAFAD00B3CEF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-OverlayTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ASMR Walk Route Overlay.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ASMR Walk Route Overlay";
+			};
+			name = Release;
+		};
+		3A51DD56304CAFAD00B3CEF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-OverlayUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "ASMR Walk Route Overlay";
+			};
+			name = Debug;
+		};
+		3A51DD57304CAFAD00B3CEF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMR-Walk-Route-OverlayUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "ASMR Walk Route Overlay";
+			};
+			name = Release;
+		};
+		3A51DD6D304CB00C00B3CEF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ADDITIONAL_SDKS = /Library/Developer/SDKs/FxPlug.sdk;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/Library/Developer/SDKs/FxPlug.sdk/Library/Frameworks,
+					/Library/Developer/Frameworks,
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ASMRWalkRouteOverlay/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ASMRWalkRouteOverlay;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalkRouteOverlay";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay-Bridging-Header.h";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				WRAPPER_EXTENSION = pluginkit;
+			};
+			name = Debug;
+		};
+		3A51DD6E304CB00C00B3CEF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ADDITIONAL_SDKS = /Library/Developer/SDKs/FxPlug.sdk;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C5HQ3DJJGW;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/Library/Developer/SDKs/FxPlug.sdk/Library/Frameworks,
+					/Library/Developer/Frameworks,
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ASMRWalkRouteOverlay/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ASMRWalkRouteOverlay;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bald-traveler.ASMRWalkRouteOverlay";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay-Bridging-Header.h";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				WRAPPER_EXTENSION = pluginkit;
 			};
 			name = Release;
 		};
@@ -1431,6 +2000,42 @@
 			buildConfigurations = (
 				3A4F4D123044A7EF00D6ADD3 /* Debug */,
 				3A4F4D133044A7EF00D6ADD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3A51DD58304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route Overlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A51DD52304CAFAD00B3CEF1 /* Debug */,
+				3A51DD53304CAFAD00B3CEF1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3A51DD59304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route OverlayTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A51DD54304CAFAD00B3CEF1 /* Debug */,
+				3A51DD55304CAFAD00B3CEF1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3A51DD5A304CAFAD00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMR Walk Route OverlayUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A51DD56304CAFAD00B3CEF1 /* Debug */,
+				3A51DD57304CAFAD00B3CEF1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3A51DD6C304CB00C00B3CEF1 /* Build configuration list for PBXNativeTarget "ASMRWalkRouteOverlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A51DD6D304CB00C00B3CEF1 /* Debug */,
+				3A51DD6E304CB00C00B3CEF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ASMRWalkRouteOverlay/ASMRRoutePackageInput.swift
+++ b/ASMRWalkRouteOverlay/ASMRRoutePackageInput.swift
@@ -1,0 +1,98 @@
+//
+//  ASMRRoutePackageInput.swift
+//  ASMRWalkRouteOverlay
+//
+
+import Foundation
+
+struct ASMRRoutePackageInput: Equatable, Sendable {
+    static let expectedSchemaVersion = 1
+    static let manifestFilename = "manifest.json"
+
+    let manifest: Manifest
+    let routePoints: [RoutePoint]
+
+    static func load(from packageURL: URL) throws -> ASMRRoutePackageInput {
+        let manifestURL = packageURL.appending(path: manifestFilename)
+        let manifest = try decode(Manifest.self, from: Data(contentsOf: manifestURL))
+
+        guard manifest.schemaVersion == expectedSchemaVersion else {
+            throw LoadError.unsupportedSchemaVersion(manifest.schemaVersion)
+        }
+
+        let routePointsURL = packageURL.appending(path: manifest.routePointsFile)
+        let routePoints = try decode([RoutePoint].self, from: Data(contentsOf: routePointsURL))
+
+        guard routePoints.count == manifest.routePointCount else {
+            throw LoadError.routePointCountMismatch(
+                expected: manifest.routePointCount,
+                actual: routePoints.count
+            )
+        }
+
+        return ASMRRoutePackageInput(
+            manifest: manifest,
+            routePoints: routePoints.sorted { $0.timestamp < $1.timestamp }
+        )
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: data)
+    }
+}
+
+extension ASMRRoutePackageInput {
+    struct Manifest: Codable, Equatable, Sendable {
+        let schemaVersion: Int
+        let packageIdentifier: UUID
+        let title: String
+        let walkDescription: String?
+        let createdAt: Date
+        let durationSeconds: TimeInterval
+        let distanceMeters: Double?
+        let mode: String
+        let recordingSource: String
+        let captureDeviceName: String?
+        let routeStartedAt: Date
+        let routeEndedAt: Date
+        let routePointCount: Int
+        let routePointsFile: String
+        let sourceGPXFile: String?
+        let videoReferences: [VideoReference]
+        let createdBy: String
+    }
+
+    struct RoutePoint: Codable, Equatable, Sendable {
+        let timestamp: Date
+        let latitude: Double
+        let longitude: Double
+        let altitude: Double?
+        let horizontalAccuracy: Double
+        let speed: Double?
+    }
+
+    struct VideoReference: Codable, Equatable, Sendable {
+        let kind: String
+        let displayName: String
+        let sourceIdentifier: String?
+        let startsAt: Date?
+        let offsetSeconds: TimeInterval?
+        let isEmbedded: Bool
+    }
+
+    enum LoadError: LocalizedError, Equatable {
+        case unsupportedSchemaVersion(Int)
+        case routePointCountMismatch(expected: Int, actual: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unsupportedSchemaVersion(version):
+                "Unsupported .asmrroute schema version \(version)."
+            case let .routePointCountMismatch(expected, actual):
+                "The .asmrroute package expected \(expected) route points but found \(actual)."
+            }
+        }
+    }
+}

--- a/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay.swift
+++ b/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay.swift
@@ -1,0 +1,83 @@
+//
+//  ASMRWalkRouteOverlay.swift
+//  ASMRWalkRouteOverlay
+//
+
+import CoreMedia
+import Foundation
+
+@objc(ASMRWalkRouteOverlayPlugin)
+final class ASMRWalkRouteOverlayPlugin: NSObject, FxTileableEffect {
+    private weak var apiManager: PROAPIAccessing?
+
+    required init?(apiManager: any PROAPIAccessing) {
+        self.apiManager = apiManager
+        super.init()
+    }
+
+    func properties(_ properties: AutoreleasingUnsafeMutablePointer<NSDictionary>?) throws {
+        properties?.pointee = [
+            kFxPropertyKey_ChangesOutputSize: false,
+            kFxPropertyKey_MayRemapTime: false,
+            kFxPropertyKey_NeedsFullBuffer: false,
+            kFxPropertyKey_PixelTransformSupport: kFxPixelTransform_Full,
+            kFxPropertyKey_VariesWhenParamsAreStatic: false
+        ] as NSDictionary
+    }
+
+    func addParameters() throws {
+        // Issue #76 only proves host discovery and lifecycle. Route package parameter UI
+        // and rendering are implemented by #77 after the target is visible in Motion/FCP.
+    }
+
+    func pluginState(
+        _ pluginState: AutoreleasingUnsafeMutablePointer<NSData>?,
+        at renderTime: CMTime,
+        quality qualityLevel: FxQuality
+    ) throws {
+        let state = ASMRWalkRouteOverlayState(
+            packagePath: "",
+            renderTimeSeconds: renderTime.seconds,
+            qualityLevel: UInt(qualityLevel)
+        )
+        pluginState?.pointee = try JSONEncoder().encode(state) as NSData
+    }
+
+    func destinationImageRect(
+        _ destinationImageRect: UnsafeMutablePointer<FxRect>,
+        sourceImages: [FxImageTile],
+        destinationImage: FxImageTile,
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        destinationImageRect.pointee = destinationImage.imagePixelBounds
+    }
+
+    func sourceTileRect(
+        _ sourceTileRect: UnsafeMutablePointer<FxRect>,
+        sourceImageIndex: UInt,
+        sourceImages: [FxImageTile],
+        destinationTileRect: FxRect,
+        destinationImage: FxImageTile,
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        sourceTileRect.pointee = kFxRect_Empty
+    }
+
+    func renderDestinationImage(
+        _ destinationImage: FxImageTile,
+        sourceImages: [FxImageTile],
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        // Deliberately no-op for target bring-up. #77 replaces this with deterministic
+        // transparent route drawing from the decoded .asmrroute package.
+    }
+}
+
+private struct ASMRWalkRouteOverlayState: Codable {
+    let packagePath: String
+    let renderTimeSeconds: Double
+    let qualityLevel: UInt
+}

--- a/ASMRWalkRouteOverlay/Info.plist
+++ b/ASMRWalkRouteOverlay/Info.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict/>
+	<key>PluginKit</key>
+	<dict>
+		<key>Attributes</key>
+		<dict>
+			<key>com.apple.protocol</key>
+			<string>FxPlug</string>
+			<key>com.apple.version</key>
+			<string>1.0</string>
+		</dict>
+		<key>PrincipalClass</key>
+		<string>FxPrincipal</string>
+		<key>Protocol</key>
+		<string>PROXPCProtocol</string>
+	</dict>
+	<key>ProPlugDictionaryVersion</key>
+	<integer>2</integer>
+	<key>ProPlugPlugInGroupList</key>
+	<array>
+		<dict>
+			<key>displayName</key>
+			<string>ASMR Walk</string>
+			<key>uuid</key>
+			<string>2BE2841F-2010-4B9E-923A-16865E315D88</string>
+		</dict>
+	</array>
+	<key>ProPlugPlugInList</key>
+	<array>
+		<dict>
+			<key>className</key>
+			<string>ASMRWalkRouteOverlayPlugin</string>
+			<key>displayName</key>
+			<string>ASMR Walk Route Overlay</string>
+			<key>groupUUID</key>
+			<string>2BE2841F-2010-4B9E-923A-16865E315D88</string>
+			<key>infoString</key>
+			<string>Animates ASMR Walk route packages over walking footage.</string>
+			<key>protocolNames</key>
+			<array>
+				<string>FxGenerator</string>
+			</array>
+			<key>uuid</key>
+			<string>D3A901A9-B749-4B9D-AF3D-F28509A457DF</string>
+			<key>version</key>
+			<string>1.0</string>
+		</dict>
+	</array>
+	<key>XPCService</key>
+	<dict>
+		<key>JoinExistingSession</key>
+		<true/>
+		<key>RunLoopType</key>
+		<string>NSRunLoop</string>
+		<key>_AdditionalSubServices</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/ASMRWalkRouteOverlay/main.swift
+++ b/ASMRWalkRouteOverlay/main.swift
@@ -1,0 +1,8 @@
+//
+//  main.swift
+//  ASMRWalkRouteOverlay
+//
+
+import Foundation
+
+FxPrincipal.startServicePrincipal()

--- a/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRRoutePackageInput.swift
+++ b/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRRoutePackageInput.swift
@@ -1,0 +1,99 @@
+//
+//  ASMRRoutePackageInput.swift
+//  ASMR Walk Route Overlay FxPlug
+//
+
+import Foundation
+
+struct ASMRRoutePackageInput: Equatable, Sendable {
+    static let expectedSchemaVersion = 1
+    static let manifestFilename = "manifest.json"
+    static let routePointsFilename = "route-points.json"
+
+    let manifest: Manifest
+    let routePoints: [RoutePoint]
+
+    static func load(from packageURL: URL) throws -> ASMRRoutePackageInput {
+        let manifestURL = packageURL.appending(path: manifestFilename)
+        let manifest = try decode(Manifest.self, from: Data(contentsOf: manifestURL))
+
+        guard manifest.schemaVersion == expectedSchemaVersion else {
+            throw LoadError.unsupportedSchemaVersion(manifest.schemaVersion)
+        }
+
+        let routePointsURL = packageURL.appending(path: manifest.routePointsFile)
+        let routePoints = try decode([RoutePoint].self, from: Data(contentsOf: routePointsURL))
+
+        guard routePoints.count == manifest.routePointCount else {
+            throw LoadError.routePointCountMismatch(
+                expected: manifest.routePointCount,
+                actual: routePoints.count
+            )
+        }
+
+        return ASMRRoutePackageInput(
+            manifest: manifest,
+            routePoints: routePoints.sorted { $0.timestamp < $1.timestamp }
+        )
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: data)
+    }
+}
+
+extension ASMRRoutePackageInput {
+    struct Manifest: Codable, Equatable, Sendable {
+        let schemaVersion: Int
+        let packageIdentifier: UUID
+        let title: String
+        let walkDescription: String?
+        let createdAt: Date
+        let durationSeconds: TimeInterval
+        let distanceMeters: Double?
+        let mode: String
+        let recordingSource: String
+        let captureDeviceName: String?
+        let routeStartedAt: Date
+        let routeEndedAt: Date
+        let routePointCount: Int
+        let routePointsFile: String
+        let sourceGPXFile: String?
+        let videoReferences: [VideoReference]
+        let createdBy: String
+    }
+
+    struct RoutePoint: Codable, Equatable, Sendable {
+        let timestamp: Date
+        let latitude: Double
+        let longitude: Double
+        let altitude: Double?
+        let horizontalAccuracy: Double
+        let speed: Double?
+    }
+
+    struct VideoReference: Codable, Equatable, Sendable {
+        let kind: String
+        let displayName: String
+        let sourceIdentifier: String?
+        let startsAt: Date?
+        let offsetSeconds: TimeInterval?
+        let isEmbedded: Bool
+    }
+
+    enum LoadError: LocalizedError, Equatable {
+        case unsupportedSchemaVersion(Int)
+        case routePointCountMismatch(expected: Int, actual: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unsupportedSchemaVersion(version):
+                "Unsupported .asmrroute schema version \(version)."
+            case let .routePointCountMismatch(expected, actual):
+                "The .asmrroute package expected \(expected) route points but found \(actual)."
+            }
+        }
+    }
+}

--- a/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay-Bridging-Header.h
+++ b/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  ASMRWalkRouteOverlay-Bridging-Header.h
+//  ASMR Walk Route Overlay FxPlug
+//
+
+#import <FxPlug/FxPlugSDK.h>

--- a/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlayPlugin.swift
+++ b/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlayPlugin.swift
@@ -1,0 +1,83 @@
+//
+//  ASMRWalkRouteOverlayPlugin.swift
+//  ASMR Walk Route Overlay FxPlug
+//
+
+import CoreMedia
+import Foundation
+
+@objc(ASMRWalkRouteOverlayPlugin)
+final class ASMRWalkRouteOverlayPlugin: NSObject, FxTileableEffect {
+    private weak var apiManager: PROAPIAccessing?
+
+    required init?(apiManager: any PROAPIAccessing) {
+        self.apiManager = apiManager
+        super.init()
+    }
+
+    func properties(_ properties: AutoreleasingUnsafeMutablePointer<NSDictionary>?) throws {
+        properties?.pointee = [
+            kFxPropertyKey_ChangesOutputSize: false,
+            kFxPropertyKey_MayRemapTime: false,
+            kFxPropertyKey_NeedsFullBuffer: false,
+            kFxPropertyKey_PixelTransformSupport: kFxPixelTransform_Full,
+            kFxPropertyKey_VariesWhenParamsAreStatic: false
+        ] as NSDictionary
+    }
+
+    func addParameters() throws {
+        // Issue #76 only proves host discovery and lifecycle. Route package parameter UI
+        // and rendering are implemented by #77 after the target is visible in Motion/FCP.
+    }
+
+    func pluginState(
+        _ pluginState: AutoreleasingUnsafeMutablePointer<NSData>?,
+        at renderTime: CMTime,
+        quality qualityLevel: FxQuality
+    ) throws {
+        let state = ASMRWalkRouteOverlayState(
+            packagePath: "",
+            renderTimeSeconds: renderTime.seconds,
+            qualityLevel: UInt(qualityLevel)
+        )
+        pluginState?.pointee = try JSONEncoder().encode(state) as NSData
+    }
+
+    func destinationImageRect(
+        _ destinationImageRect: UnsafeMutablePointer<FxRect>,
+        sourceImages: [FxImageTile],
+        destinationImage: FxImageTile,
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        destinationImageRect.pointee = destinationImage.imagePixelBounds
+    }
+
+    func sourceTileRect(
+        _ sourceTileRect: UnsafeMutablePointer<FxRect>,
+        sourceImageIndex: UInt,
+        sourceImages: [FxImageTile],
+        destinationTileRect: FxRect,
+        destinationImage: FxImageTile,
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        sourceTileRect.pointee = kFxRect_Empty
+    }
+
+    func renderDestinationImage(
+        _ destinationImage: FxImageTile,
+        sourceImages: [FxImageTile],
+        pluginState: Data?,
+        at renderTime: CMTime
+    ) throws {
+        // Deliberately no-op for target bring-up. #77 replaces this with deterministic
+        // transparent route drawing from the decoded .asmrroute package.
+    }
+}
+
+private struct ASMRWalkRouteOverlayState: Codable {
+    let packagePath: String
+    let renderTimeSeconds: Double
+    let qualityLevel: UInt
+}

--- a/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/Info.plist
+++ b/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/Info.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict/>
+	<key>PluginKit</key>
+	<dict>
+		<key>Attributes</key>
+		<dict>
+			<key>com.apple.protocol</key>
+			<string>FxPlug</string>
+			<key>com.apple.version</key>
+			<string>1.0</string>
+		</dict>
+		<key>PrincipalClass</key>
+		<string>FxPrincipal</string>
+		<key>Protocol</key>
+		<string>PROXPCProtocol</string>
+	</dict>
+	<key>ProPlugDictionaryVersion</key>
+	<integer>2</integer>
+	<key>ProPlugPlugInGroupList</key>
+	<array>
+		<dict>
+			<key>displayName</key>
+			<string>ASMR Walk</string>
+			<key>uuid</key>
+			<string>2BE2841F-2010-4B9E-923A-16865E315D88</string>
+		</dict>
+	</array>
+	<key>ProPlugPlugInList</key>
+	<array>
+		<dict>
+			<key>className</key>
+			<string>ASMRWalkRouteOverlayPlugin</string>
+			<key>displayName</key>
+			<string>ASMR Walk Route Overlay</string>
+			<key>groupUUID</key>
+			<string>2BE2841F-2010-4B9E-923A-16865E315D88</string>
+			<key>infoString</key>
+			<string>Animates ASMR Walk route packages over walking footage.</string>
+			<key>protocolNames</key>
+			<array>
+				<string>FxGenerator</string>
+			</array>
+			<key>uuid</key>
+			<string>D3A901A9-B749-4B9D-AF3D-F28509A457DF</string>
+			<key>version</key>
+			<string>1.0</string>
+		</dict>
+	</array>
+	<key>XPCService</key>
+	<dict>
+		<key>JoinExistingSession</key>
+		<true/>
+		<key>RunLoopType</key>
+		<string>NSRunLoop</string>
+		<key>_AdditionalSubServices</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/main.swift
+++ b/FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/main.swift
@@ -1,0 +1,8 @@
+//
+//  main.swift
+//  ASMR Walk Route Overlay FxPlug
+//
+
+import Foundation
+
+FxPrincipal.startServicePrincipal()

--- a/FxPlug/ASMRWalkRouteOverlay/Documentation/ISSUE_76_OWNER_SETUP.md
+++ b/FxPlug/ASMRWalkRouteOverlay/Documentation/ISSUE_76_OWNER_SETUP.md
@@ -1,0 +1,58 @@
+# Issue #76 Owner Setup: FxPlug Generator Target
+
+Issue #76 creates the bring-up path for the ASMR Walk Route Overlay FxPlug generator. The checked-in scaffold under `FxPlug/ASMRWalkRouteOverlay` documents the desired shape, and the active Xcode target now uses the target-local files under `ASMRWalkRouteOverlay`.
+
+## Local Prerequisites
+
+- Install the FxPlug SDK.
+- Confirm these paths exist:
+  - `/Library/Developer/SDKs/FxPlug.sdk`
+  - `/Library/Developer/SDKs/FxPlug.sdk/Library/Frameworks/FxPlug.framework`
+  - `/Library/Developer/SDKs/FxPlug.sdk/Library/Frameworks/PluginManager.framework`
+  - `/Library/Developer/Frameworks/FxPlug.framework`
+  - `/Library/Developer/Frameworks/PluginManager.framework`
+- Install Motion and/or Final Cut Pro for host validation.
+
+## Xcode Target Setup
+
+1. Create a new macOS wrapper app target named `ASMR Walk Route Overlay`.
+2. Add a new XPC Service target named `ASMRWalkRouteOverlay`.
+3. Set the XPC service target's Wrapper Extension build setting to `pluginkit`.
+4. Embed the XPC service in the wrapper app using an Embed PlugIns or Copy Files build phase with code signing enabled.
+5. Add `FxPlug.framework` and `PluginManager.framework` to the XPC service target.
+6. Add these build settings to the XPC service target:
+   - Framework Search Paths: `/Library/Developer/SDKs/FxPlug.sdk/Library/Frameworks /Library/Developer/Frameworks $(inherited)`
+   - Additional SDKs: `/Library/Developer/SDKs/FxPlug.sdk`
+   - Objective-C Bridging Header: `FxPlug/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay/ASMRWalkRouteOverlay-Bridging-Header.h`
+7. Use `ASMRWalkRouteOverlay/Info.plist` as the XPC service Info.plist.
+8. Add these source files to the XPC service target:
+   - `main.swift`
+   - `ASMRWalkRouteOverlay.swift`
+   - `ASMRRoutePackageInput.swift`
+
+## Bundle Identifiers
+
+Suggested development identifiers:
+
+- Wrapper app: `com.bald-traveler.ASMRWalk.RouteOverlay`
+- XPC service/plugin: `com.bald-traveler.ASMRWalk.RouteOverlay.ASMRWalkRouteOverlay`
+
+Use the same Apple development team as the Mac importer unless signing policy requires a separate identifier.
+
+## Validation
+
+1. Build the wrapper app and XPC service.
+2. Confirm `ASMRWalkRouteOverlay.pluginkit` is embedded under `ASMR Walk Route Overlay.app/Contents/PlugIns`.
+3. Run the wrapper app once.
+4. Query PlugInKit:
+
+   ```sh
+   pluginkit -m -p FxPlug | grep "ASMR Walk Route Overlay"
+   ```
+
+5. Launch Motion and confirm the generator appears under the `ASMR Walk` group.
+6. For Final Cut Pro, create or update the Motion template wrapper needed to expose the generator to Final Cut Pro.
+
+## Scope Boundary
+
+This issue is complete when the target builds and the generator is discoverable. Real route drawing from `.asmrroute` packages belongs to #77, timing/performance refinements belong to #78, and full FCP/Motion release validation belongs to #79.

--- a/Journal.md
+++ b/Journal.md
@@ -467,6 +467,14 @@ Issue 98 gives the Mac importer its own app icon while keeping it visually tied 
 
 That detail matters because the Icon Composer file is not just a picture; it is a tiny stage set with the hiker, route marker, and map on separate layers. Flattening it into PNG slots lost the composition Xcode is designed to preserve. The Mac target already pointed at `AppIcon`, so the clean move was to add the matching Icon Composer package without touching project settings.
 
+### The FxPlug Doorframe Goes Up
+
+Issue 76 starts the Final Cut Pro and Motion chapter by putting up the doorframe before trying to decorate the room. FxPlug 4 wants a specific shape: a macOS wrapper app, an XPC service with a `pluginkit` wrapper, PlugInKit metadata, and a Swift class that conforms to `FxTileableEffect` even when the host advertises it as an `FxGenerator`.
+
+The first pass is intentionally a no-op renderer. That sounds underwhelming, but it is the right kind of boring: before route geometry, map styling, and timing modes arrive, the plugin has to build, register, and show up in Motion/FCP. The `.asmrroute` reader is already separated from the rendering class so #77 can focus on drawing the trail instead of untangling package validation from host lifecycle code.
+
+The Xcode target bring-up had one practical wrinkle: the wrapper app has to copy the `ASMRWalkRouteOverlay.pluginkit` product into its `Contents/PlugIns` directory. Without that copy phase, the plugin can build perfectly and still be invisible to the host, like a stage prop left in the parking lot. The branch now builds both the XPC service and the wrapper app, and the built app contains the embedded pluginkit where PlugInKit expects to find it.
+
 ## Engineer's Wisdom
 
 - Make unfinished behavior visibly unfinished. A polished button wired to nothing is worse than an honest foundation state.


### PR DESCRIPTION
## Summary
- Adds the ASMR Walk Route Overlay macOS wrapper app and embedded FxPlug pluginkit target setup.
- Adds the initial no-op FxPlug generator implementation and `.asmrroute` package input loader scaffold for future rendering work.
- Documents owner validation/setup steps for Issue #76 and records the target bring-up notes in `Journal.md`.

## Validation
- `xcodebuild -project "ASMR Walk.xcodeproj" -scheme "ASMR Walk Route Overlay" -configuration Release -derivedDataPath /private/tmp/ASMRWalkIssue76PRDerivedData -destination 'platform=macOS' build`\n- Verified the Release wrapper embeds `ASMRWalkRouteOverlay.pluginkit` under `Contents/PlugIns`.\n\nCloses #76.